### PR TITLE
ci: add 30-min timeout, print semgrep findings, and expose artifact

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -14,6 +14,7 @@ jobs:
   flake8:
     name: PEP 8 – flake8
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint-and-validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -14,6 +14,7 @@ jobs:
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     defaults:
       run:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,12 +11,12 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: semgrep/semgrep
 
@@ -25,18 +25,23 @@ jobs:
 
       - name: Run Semgrep
         run: |
-          semgrep ci \
+          set +e
+          semgrep scan \
             --config=auto \
             --config=p/django \
             --config=p/javascript \
             --config=p/typescript \
             --config=p/owasp-top-ten \
-            --sarif --output semgrep-results.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+            --text \
+            --output semgrep-results.txt
+          SEMGREP_EXIT=$?
+          echo "---- Semgrep findings ----"
+          cat semgrep-results.txt
+          exit $SEMGREP_EXIT
 
-      - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload Semgrep report as artifact
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          sarif_file: semgrep-results.sarif
+          name: semgrep-report
+          path: semgrep-results.txt


### PR DESCRIPTION
- Add timeout-minutes: 30 to all workflow jobs
- Switch semgrep from `ci` (requires app token) to `scan` (no token needed)
- Print findings to the Actions log via set+e / cat so devs see what failed
- Upload semgrep-results.txt as a downloadable artifact on every run