### PR TITLE
[FEATURE] Geo-based shop search using Haversine formula

### DIFF
--- a/toddy_shop_backend/shops/geo_utils.py
+++ b/toddy_shop_backend/shops/geo_utils.py
@@ -1,0 +1,35 @@
+import math
+
+
+def haversine(lat1, lng1, lat2, lng2):
+    """
+    Calculate the great-circle distance in kilometres between two points
+    on Earth using the Haversine formula.
+    """
+    R = 6371  # Earth radius in km
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lng2 - lng1)
+
+    a = (
+        math.sin(dphi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    )
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def filter_shops_by_distance(queryset, lat, lng, radius_km):
+    """
+    Filter and annotate a ToddyShop queryset by proximity.
+    Returns a list of (shop, distance_km) tuples sorted by distance.
+    """
+    results = []
+    for shop in queryset:
+        place = shop.place
+        if place.latitude is None or place.longitude is None:
+            continue
+        distance = haversine(lat, lng, float(place.latitude), float(place.longitude))
+        if distance <= radius_km:
+            results.append((shop, round(distance, 2)))
+    results.sort(key=lambda x: x[1])
+    return results

--- a/toddy_shop_backend/shops/serializers.py
+++ b/toddy_shop_backend/shops/serializers.py
@@ -139,6 +139,7 @@ class ToddyShopListSerializer(serializers.ModelSerializer):
     status = StatusSerializer(read_only=True)
     avg_rating = serializers.SerializerMethodField()
     review_count = serializers.IntegerField(source="reviews.count", read_only=True)
+    distance_km = serializers.FloatField(read_only=True, default=None)
 
     class Meta:
         model = ToddyShop
@@ -150,6 +151,7 @@ class ToddyShopListSerializer(serializers.ModelSerializer):
             "status",
             "avg_rating",
             "review_count",
+            "distance_km",
             "created_at",
         ]
 

--- a/toddy_shop_backend/shops/views.py
+++ b/toddy_shop_backend/shops/views.py
@@ -7,6 +7,7 @@ from drf_spectacular.utils import extend_schema
 from core.models import Status
 from shared.permissions import IsAdmin, IsShopOwner, IsShopOwnerOrAdmin
 from shared.responses import APIResponse
+from .geo_utils import filter_shops_by_distance
 
 from .models import (
     ShopFoodItem,
@@ -75,6 +76,35 @@ class ToddyShopViewSet(viewsets.ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         qs = self.filter_queryset(self.get_queryset())
+
+        # Geo-based proximity filter
+        params = request.query_params
+        lat = params.get("lat")
+        lng = params.get("lng")
+        if lat and lng:
+            try:
+                lat = float(lat)
+                lng = float(lng)
+                radius = float(params.get("radius", 10))
+            except ValueError:
+                return APIResponse(
+                    data=None,
+                    message="Invalid lat, lng or radius — must be numeric.",
+                    status=400,
+                    is_success=False,
+                )
+            nearby = filter_shops_by_distance(qs, lat, lng, radius)
+            for shop, distance in nearby:
+                shop.distance_km = distance
+            shops = [shop for shop, _ in nearby]
+            data = ToddyShopListSerializer(
+                shops, many=True, context={"request": request}
+            ).data
+            return APIResponse(
+                data=data,
+                message=f"Shops within {radius}km retrieved successfully.",
+            )
+
         page = self.paginate_queryset(qs)
         if page is not None:
             data = ToddyShopListSerializer(


### PR DESCRIPTION
## Summary

Implements **Issue #35** — proximity-based shop search so users can find toddy shops near their location.

## Changes

### `shops/geo_utils.py` (new)
- `haversine(lat1, lng1, lat2, lng2)` — calculates distance in km between two coordinates
- `filter_shops_by_distance(queryset, lat, lng, radius_km)` — filters and sorts shops by distance

### `shops/views.py`
- `GET /api/v1/shops/?lat=9.49&lng=76.33&radius=10` triggers geo filter
- Results sorted by `distance_km` ascending
- Falls back to normal filtering if `lat`/`lng` not provided
- Returns `400` with clear message for invalid numeric values

### `shops/serializers.py`
- `distance_km` added to `ToddyShopListSerializer` — populated when geo search is used, `null` otherwise

## How This Wires to the Frontend Map

This API is designed to power the `/explore` page map directly:

```
1. User opens /explore page
2. Browser requests location via navigator.geolocation.getCurrentPosition()
3. Frontend calls GET /api/v1/shops/?lat={lat}&lng={lng}&radius=20
4. Response returns shops with place.latitude, place.longitude, distance_km
5. Map renders real markers using place coordinates
6. Side drawer shows shops sorted by distance_km
```

Frontend wiring is tracked separately in issue #36.

## Example

```bash
curl "http://localhost:8000/api/v1/shops/?lat=9.4981&lng=76.3388&radius=15"
```

```json
{
  "status": "success",
  "message": "Shops within 15km retrieved successfully.",
  "data": [
    {
      "id": 1,
      "name": "Backwater Pearl",
      "place": { "latitude": "9.498100", "longitude": "76.338800" },
      "distance_km": 1.2
    }
  ]
}
```

## Test plan

- [ ] `GET /api/v1/shops/?lat=9.49&lng=76.33&radius=10` returns shops within 10km
- [ ] Results are sorted by `distance_km` ascending
- [ ] `distance_km` is `null` when no geo params provided
- [ ] `GET /api/v1/shops/?lat=abc&lng=76.33` returns 400
- [ ] Normal filtering still works without geo params

Closes #35