### PR TITLE
[FEATURE] Add ordering support to shop list endpoint

### DIFF
--- a/toddy_shop_backend/core/migrations/0001_initial.py
+++ b/toddy_shop_backend/core/migrations/0001_initial.py
@@ -12,177 +12,402 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('auth', '0012_alter_user_first_name_max_length'),
+        ("auth", "0012_alter_user_first_name_max_length"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='District',
+            name="District",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'db_table': 'districts',
-                'ordering': ['name'],
+                "db_table": "districts",
+                "ordering": ["name"],
             },
         ),
         migrations.CreateModel(
-            name='Facility',
+            name="Facility",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'verbose_name_plural': 'facilities',
-                'db_table': 'facilities',
+                "verbose_name_plural": "facilities",
+                "db_table": "facilities",
             },
         ),
         migrations.CreateModel(
-            name='FoodCategory',
+            name="FoodCategory",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'verbose_name_plural': 'food categories',
-                'db_table': 'food_categories',
+                "verbose_name_plural": "food categories",
+                "db_table": "food_categories",
             },
         ),
         migrations.CreateModel(
-            name='HygieneTag',
+            name="HygieneTag",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'db_table': 'hygiene_tags',
+                "db_table": "hygiene_tags",
             },
         ),
         migrations.CreateModel(
-            name='LicenseType',
+            name="LicenseType",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'db_table': 'license_types',
+                "db_table": "license_types",
             },
         ),
         migrations.CreateModel(
-            name='MediaType',
+            name="MediaType",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=50, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50, unique=True)),
             ],
             options={
-                'db_table': 'media_types',
+                "db_table": "media_types",
             },
         ),
         migrations.CreateModel(
-            name='RatingType',
+            name="RatingType",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'db_table': 'rating_types',
+                "db_table": "rating_types",
             },
         ),
         migrations.CreateModel(
-            name='ReviewCategory',
+            name="ReviewCategory",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'verbose_name_plural': 'review categories',
-                'db_table': 'review_categories',
+                "verbose_name_plural": "review categories",
+                "db_table": "review_categories",
             },
         ),
         migrations.CreateModel(
-            name='ShopCategory',
+            name="ShopCategory",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
             ],
             options={
-                'verbose_name_plural': 'shop categories',
-                'db_table': 'shop_categories',
+                "verbose_name_plural": "shop categories",
+                "db_table": "shop_categories",
             },
         ),
         migrations.CreateModel(
-            name='Status',
+            name="Status",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=50, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50, unique=True)),
             ],
             options={
-                'verbose_name_plural': 'statuses',
-                'db_table': 'statuses',
+                "verbose_name_plural": "statuses",
+                "db_table": "statuses",
             },
         ),
         migrations.CreateModel(
-            name='UserRole',
+            name="UserRole",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=50, unique=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50, unique=True)),
             ],
             options={
-                'db_table': 'user_roles',
+                "db_table": "user_roles",
             },
         ),
         migrations.CreateModel(
-            name='User',
+            name="User",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
-                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username')),
-                ('first_name', models.CharField(blank=True, max_length=150, verbose_name='first name')),
-                ('last_name', models.CharField(blank=True, max_length=150, verbose_name='last name')),
-                ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
-                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
-                ('phone', models.CharField(blank=True, max_length=15)),
-                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', related_query_name='user', to='auth.group', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.permission', verbose_name='user permissions')),
-                ('role', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='users', to='core.userrole')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                (
+                    "last_login",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="last login"
+                    ),
+                ),
+                (
+                    "is_superuser",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates that this user has all permissions without explicitly assigning them.",
+                        verbose_name="superuser status",
+                    ),
+                ),
+                (
+                    "username",
+                    models.CharField(
+                        error_messages={
+                            "unique": "A user with that username already exists."
+                        },
+                        help_text="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                        max_length=150,
+                        unique=True,
+                        validators=[
+                            django.contrib.auth.validators.UnicodeUsernameValidator()
+                        ],
+                        verbose_name="username",
+                    ),
+                ),
+                (
+                    "first_name",
+                    models.CharField(
+                        blank=True, max_length=150, verbose_name="first name"
+                    ),
+                ),
+                (
+                    "last_name",
+                    models.CharField(
+                        blank=True, max_length=150, verbose_name="last name"
+                    ),
+                ),
+                (
+                    "email",
+                    models.EmailField(
+                        blank=True, max_length=254, verbose_name="email address"
+                    ),
+                ),
+                (
+                    "is_staff",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates whether the user can log into this admin site.",
+                        verbose_name="staff status",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Designates whether this user should be treated as active. Unselect this instead of deleting accounts.",
+                        verbose_name="active",
+                    ),
+                ),
+                (
+                    "date_joined",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, verbose_name="date joined"
+                    ),
+                ),
+                ("phone", models.CharField(blank=True, max_length=15)),
+                (
+                    "groups",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.group",
+                        verbose_name="groups",
+                    ),
+                ),
+                (
+                    "user_permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Specific permissions for this user.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.permission",
+                        verbose_name="user permissions",
+                    ),
+                ),
+                (
+                    "role",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="users",
+                        to="core.userrole",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'users',
+                "db_table": "users",
             },
             managers=[
-                ('objects', django.contrib.auth.models.UserManager()),
+                ("objects", django.contrib.auth.models.UserManager()),
             ],
         ),
         migrations.CreateModel(
-            name='FoodItem',
+            name="FoodItem",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100)),
-                ('food_category', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='food_items', to='core.foodcategory')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+                (
+                    "food_category",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="food_items",
+                        to="core.foodcategory",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'food_items',
-                'unique_together': {('name', 'food_category')},
+                "db_table": "food_items",
+                "unique_together": {("name", "food_category")},
             },
         ),
         migrations.CreateModel(
-            name='Place',
+            name="Place",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100)),
-                ('address', models.TextField(blank=True)),
-                ('latitude', models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True)),
-                ('longitude', models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True)),
-                ('district', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='places', to='core.district')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+                ("address", models.TextField(blank=True)),
+                (
+                    "latitude",
+                    models.DecimalField(
+                        blank=True, decimal_places=6, max_digits=9, null=True
+                    ),
+                ),
+                (
+                    "longitude",
+                    models.DecimalField(
+                        blank=True, decimal_places=6, max_digits=9, null=True
+                    ),
+                ),
+                (
+                    "district",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="places",
+                        to="core.district",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'places',
-                'unique_together': {('name', 'district')},
+                "db_table": "places",
+                "unique_together": {("name", "district")},
             },
         ),
     ]

--- a/toddy_shop_backend/shops/migrations/0001_initial.py
+++ b/toddy_shop_backend/shops/migrations/0001_initial.py
@@ -11,110 +11,313 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('core', '0001_initial'),
+        ("core", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='ToddyShop',
+            name="ToddyShop",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('name', models.CharField(max_length=200)),
-                ('description', models.TextField(blank=True)),
-                ('address', models.TextField()),
-                ('phone', models.CharField(blank=True, max_length=15)),
-                ('email', models.EmailField(blank=True, max_length=254)),
-                ('website', models.URLField(blank=True)),
-                ('category', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='shops', to='core.shopcategory')),
-                ('facilities', models.ManyToManyField(blank=True, related_name='shops', to='core.facility')),
-                ('hygiene_tags', models.ManyToManyField(blank=True, related_name='shops', to='core.hygienetag')),
-                ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='shops', to=settings.AUTH_USER_MODEL)),
-                ('place', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='shops', to='core.place')),
-                ('status', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='shops', to='core.status')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("name", models.CharField(max_length=200)),
+                ("description", models.TextField(blank=True)),
+                ("address", models.TextField()),
+                ("phone", models.CharField(blank=True, max_length=15)),
+                ("email", models.EmailField(blank=True, max_length=254)),
+                ("website", models.URLField(blank=True)),
+                (
+                    "category",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="shops",
+                        to="core.shopcategory",
+                    ),
+                ),
+                (
+                    "facilities",
+                    models.ManyToManyField(
+                        blank=True, related_name="shops", to="core.facility"
+                    ),
+                ),
+                (
+                    "hygiene_tags",
+                    models.ManyToManyField(
+                        blank=True, related_name="shops", to="core.hygienetag"
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="shops",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "place",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="shops",
+                        to="core.place",
+                    ),
+                ),
+                (
+                    "status",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="shops",
+                        to="core.status",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'toddy_shops',
-                'ordering': ['-created_at'],
+                "db_table": "toddy_shops",
+                "ordering": ["-created_at"],
             },
         ),
         migrations.CreateModel(
-            name='ShopMedia',
+            name="ShopMedia",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('file', models.FileField(upload_to='shop_media/%Y/%m/')),
-                ('caption', models.CharField(blank=True, max_length=255)),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('media_type', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.mediatype')),
-                ('uploaded_by', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='uploaded_media', to=settings.AUTH_USER_MODEL)),
-                ('shop', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='media', to='shops.toddyshop')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("file", models.FileField(upload_to="shop_media/%Y/%m/")),
+                ("caption", models.CharField(blank=True, max_length=255)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "media_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT, to="core.mediatype"
+                    ),
+                ),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="uploaded_media",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "shop",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="media",
+                        to="shops.toddyshop",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'shop_media',
+                "db_table": "shop_media",
             },
         ),
         migrations.CreateModel(
-            name='ShopLicense',
+            name="ShopLicense",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('license_number', models.CharField(max_length=100, unique=True)),
-                ('issued_date', models.DateField()),
-                ('expiry_date', models.DateField(db_index=True)),
-                ('license_status', models.CharField(choices=[('active', 'Active'), ('expired', 'Expired'), ('unknown', 'Unknown'), ('restricted', 'Restricted')], default='unknown', max_length=20)),
-                ('license_type', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.licensetype')),
-                ('shop', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='license', to='shops.toddyshop')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("license_number", models.CharField(max_length=100, unique=True)),
+                ("issued_date", models.DateField()),
+                ("expiry_date", models.DateField(db_index=True)),
+                (
+                    "license_status",
+                    models.CharField(
+                        choices=[
+                            ("active", "Active"),
+                            ("expired", "Expired"),
+                            ("unknown", "Unknown"),
+                            ("restricted", "Restricted"),
+                        ],
+                        default="unknown",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "license_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="core.licensetype",
+                    ),
+                ),
+                (
+                    "shop",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="license",
+                        to="shops.toddyshop",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'shop_licenses',
+                "db_table": "shop_licenses",
             },
         ),
         migrations.CreateModel(
-            name='ShopReview',
+            name="ShopReview",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('title', models.CharField(blank=True, max_length=200)),
-                ('body', models.TextField()),
-                ('category', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.reviewcategory')),
-                ('status', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='reviews', to='core.status')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='reviews', to=settings.AUTH_USER_MODEL)),
-                ('shop', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='reviews', to='shops.toddyshop')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("title", models.CharField(blank=True, max_length=200)),
+                ("body", models.TextField()),
+                (
+                    "category",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="core.reviewcategory",
+                    ),
+                ),
+                (
+                    "status",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="reviews",
+                        to="core.status",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reviews",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "shop",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reviews",
+                        to="shops.toddyshop",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'shop_reviews',
-                'unique_together': {('shop', 'user')},
+                "db_table": "shop_reviews",
+                "unique_together": {("shop", "user")},
             },
         ),
         migrations.CreateModel(
-            name='ShopRating',
+            name="ShopRating",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('score', models.PositiveSmallIntegerField(validators=[django.core.validators.MinValueValidator(1), django.core.validators.MaxValueValidator(10)])),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('rating_type', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.ratingtype')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='ratings', to=settings.AUTH_USER_MODEL)),
-                ('shop', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='ratings', to='shops.toddyshop')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "score",
+                    models.PositiveSmallIntegerField(
+                        validators=[
+                            django.core.validators.MinValueValidator(1),
+                            django.core.validators.MaxValueValidator(10),
+                        ]
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "rating_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="core.ratingtype",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="ratings",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "shop",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="ratings",
+                        to="shops.toddyshop",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'shop_ratings',
-                'unique_together': {('shop', 'user', 'rating_type')},
+                "db_table": "shop_ratings",
+                "unique_together": {("shop", "user", "rating_type")},
             },
         ),
         migrations.CreateModel(
-            name='ShopFoodItem',
+            name="ShopFoodItem",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('price', models.DecimalField(blank=True, decimal_places=2, max_digits=8, null=True)),
-                ('is_available', models.BooleanField(default=True)),
-                ('food_item', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='core.fooditem')),
-                ('shop', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='shop_food_items', to='shops.toddyshop')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "price",
+                    models.DecimalField(
+                        blank=True, decimal_places=2, max_digits=8, null=True
+                    ),
+                ),
+                ("is_available", models.BooleanField(default=True)),
+                (
+                    "food_item",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="core.fooditem"
+                    ),
+                ),
+                (
+                    "shop",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="shop_food_items",
+                        to="shops.toddyshop",
+                    ),
+                ),
             ],
             options={
-                'db_table': 'shop_food_items',
-                'unique_together': {('shop', 'food_item')},
+                "db_table": "shop_food_items",
+                "unique_together": {("shop", "food_item")},
             },
         ),
     ]

--- a/toddy_shop_backend/shops/serializers.py
+++ b/toddy_shop_backend/shops/serializers.py
@@ -137,8 +137,8 @@ class ToddyShopListSerializer(serializers.ModelSerializer):
     place = PlaceReadSerializer(read_only=True)
     category = ShopCategorySerializer(read_only=True)
     status = StatusSerializer(read_only=True)
-    avg_rating = serializers.SerializerMethodField()
-    review_count = serializers.IntegerField(source="reviews.count", read_only=True)
+    avg_rating = serializers.FloatField(read_only=True)
+    review_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = ToddyShop
@@ -152,11 +152,6 @@ class ToddyShopListSerializer(serializers.ModelSerializer):
             "review_count",
             "created_at",
         ]
-
-    def get_avg_rating(self, obj):
-        result = obj.ratings.aggregate(avg=Avg("score"))
-        avg = result.get("avg")
-        return round(avg, 1) if avg is not None else None
 
 
 class ToddyShopDetailSerializer(serializers.ModelSerializer):

--- a/toddy_shop_backend/shops/views.py
+++ b/toddy_shop_backend/shops/views.py
@@ -36,11 +36,15 @@ from .serializers import (
 @extend_schema(tags=["Shops"])
 class ToddyShopViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
-        qs = ToddyShop.objects.select_related(
-            "place__district", "category", "status", "owner__role"
-        ).prefetch_related("facilities", "hygiene_tags").annotate(
-            avg_rating=Avg("ratings__score"),
-            review_count=Count("reviews", distinct=True),
+        qs = (
+            ToddyShop.objects.select_related(
+                "place__district", "category", "status", "owner__role"
+            )
+            .prefetch_related("facilities", "hygiene_tags")
+            .annotate(
+                avg_rating=Avg("ratings__score"),
+                review_count=Count("reviews", distinct=True),
+            )
         )
 
         user = self.request.user

--- a/toddy_shop_backend/shops/views.py
+++ b/toddy_shop_backend/shops/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Avg, Count
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
@@ -37,7 +38,10 @@ class ToddyShopViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         qs = ToddyShop.objects.select_related(
             "place__district", "category", "status", "owner__role"
-        ).prefetch_related("facilities", "hygiene_tags")
+        ).prefetch_related("facilities", "hygiene_tags").annotate(
+            avg_rating=Avg("ratings__score"),
+            review_count=Count("reviews", distinct=True),
+        )
 
         user = self.request.user
         if not (user.is_authenticated and user.is_admin):

--- a/toddy_shop_backend/shops/views.py
+++ b/toddy_shop_backend/shops/views.py
@@ -2,6 +2,7 @@ from django.db.models import Avg, Count
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter
 from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
 
@@ -35,6 +36,10 @@ from .serializers import (
 
 @extend_schema(tags=["Shops"])
 class ToddyShopViewSet(viewsets.ModelViewSet):
+    filter_backends = [OrderingFilter]
+    ordering_fields = ["avg_rating", "review_count", "created_at", "name"]
+    ordering = ["-created_at"]
+
     def get_queryset(self):
         qs = (
             ToddyShop.objects.select_related(


### PR DESCRIPTION
## Description

- **Summary of changes:** Adds `OrderingFilter` to `ToddyShopViewSet` so clients can sort the shop list by rating, review count, name, or creation date via a `?ordering=` query param
- **Reasoning / motivation:** Without server-side ordering, clients must fetch all results and sort client-side — this breaks pagination and wastes bandwidth
- **Additional context:** Depends on #39 (N+1 fix) — `avg_rating` and `review_count` must be annotated on the queryset for DB-level ordering to work. **This PR should not be merged before #39.**

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] CI / tooling change
- [ ] Documentation update
- [ ] Security fix

---

## Related Issues

Closes #40

Blocked by #39

---

## Backend Checklist

- [ ] Models: migrations created and reviewed (`makemigrations` + `migrate`)
- [x] Serializers: input validation is correct; no sensitive fields exposed
- [x] Views: correct permission classes applied (`IsAdmin`, `IsShopOwner`, `IsShopOwnerOrAdmin`)
- [x] URLs: new endpoints registered in `urls.py`
- [x] All responses use `APIResponse` wrapper
- [x] No raw SQL or unfiltered querysets exposed to unauthenticated users
- [x] `manage.py check` passes locally

---

## Tests

- [x] Tested happy path and edge cases manually

```bash
# Highest rated first
curl "http://localhost:8000/api/v1/shops/?ordering=-avg_rating"

# Most reviewed first
curl "http://localhost:8000/api/v1/shops/?ordering=-review_count"

# Alphabetical
curl "http://localhost:8000/api/v1/shops/?ordering=name"

# Newest first (default)
curl "http://localhost:8000/api/v1/shops/?ordering=-created_at"

# Combined
curl "http://localhost:8000/api/v1/shops/?ordering=-avg_rating,-review_count"
```

---

## Docs / Notes

Allowed ordering fields: `avg_rating`, `review_count`, `created_at`, `name`. Default ordering is `-created_at` (newest first). Prefix with `-` for descending.