### PR TITLE
[FEATURE] District statistics endpoint — shop count and avg rating per district

### DIFF
--- a/toddy_shop_backend/core/views.py
+++ b/toddy_shop_backend/core/views.py
@@ -1,4 +1,6 @@
+from django.db.models import Avg, Count, Q
 from rest_framework import generics, permissions, viewsets
+from rest_framework.decorators import action
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from drf_spectacular.utils import extend_schema
@@ -158,6 +160,34 @@ class StatusViewSet(LookupViewSet):
 class DistrictViewSet(LookupViewSet):
     queryset = District.objects.all()
     serializer_class = DistrictSerializer
+
+    @action(detail=False, methods=["get"], permission_classes=[permissions.AllowAny])
+    def stats(self, request):
+        active_filter = Q(places__toddyshops__status__name="Active")
+        districts = District.objects.annotate(
+            shop_count=Count(
+                "places__toddyshops",
+                filter=active_filter,
+                distinct=True,
+            ),
+            avg_rating=Avg(
+                "places__toddyshops__ratings__score",
+                filter=active_filter,
+            ),
+        ).order_by("-shop_count", "name")
+
+        data = [
+            {
+                "id": d.id,
+                "name": d.name,
+                "shop_count": d.shop_count,
+                "avg_rating": (
+                    round(d.avg_rating, 1) if d.avg_rating is not None else None
+                ),
+            }
+            for d in districts
+        ]
+        return APIResponse(data=data, message="District statistics retrieved.")
 
 
 @extend_schema(tags=["Lookups"])


### PR DESCRIPTION
## Description

- **Summary of changes:** Adds `GET /api/v1/districts/stats/` endpoint that returns shop count and average rating per district for all 14 Kerala districts
- **Reasoning / motivation:** Enables an "explore by district" feature on the frontend — users can see which districts have the most shops and highest ratings without fetching all shop data
- **Additional context:** Single query using `annotate()` — no N+1. Only counts active shops.

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] CI / tooling change
- [ ] Documentation update
- [ ] Security fix

---

## Related Issues

Closes #44

---

## Backend Checklist

- [x] Models: no model changes required
- [x] Serializers: no sensitive fields exposed
- [x] Views: correct permission classes applied (`AllowAny` — public read-only stats)
- [x] URLs: endpoint auto-registered via `DistrictViewSet` router action
- [x] All responses use `APIResponse` wrapper
- [x] No raw SQL or unfiltered querysets exposed to unauthenticated users
- [x] `manage.py check` passes locally

---

## Tests

- [x] Tested happy path manually

```bash
# Get district stats
curl http://localhost:8000/api/v1/districts/stats/

# Response
{
  "success": true,
  "message": "District statistics retrieved.",
  "data": [
    {
      "id": 2,
      "name": "Ernakulam",
      "shop_count": 3,
      "avg_rating": 4.2
    },
    {
      "id": 1,
      "name": "Alappuzha",
      "shop_count": 1,
      "avg_rating": null
    },
    ...
  ]
}
```

---

## Docs / Notes

- Endpoint: `GET /api/v1/districts/stats/`
- Public access (no auth required)
- Only counts shops with `status=Active`
- Results ordered by `shop_count` descending, then `name` ascending
- Single annotated query — O(1) queries regardless of data size