### PR TITLE
[FIX] Exclude migrations from black formatter to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 119
+exclude = '''
+/(
+    migrations
+  | venv
+  | \.venv
+)/
+'''

--- a/toddy_shop_backend/pyproject.toml
+++ b/toddy_shop_backend/pyproject.toml
@@ -13,3 +13,13 @@ dependencies = [
     "Pillow>=11.0.0",
     "drf-spectacular>=0.29.0",
 ]
+
+[tool.black]
+line-length = 119
+exclude = '''
+/(
+    migrations
+  | venv
+  | \.venv
+)/
+'''


### PR DESCRIPTION
## Description

- **Summary of changes:** Adds `[tool.black]` config to `pyproject.toml` to exclude `migrations/` and `venv/` directories from black formatting checks
- **Reasoning / motivation:** Django auto-generates migration files that don't conform to black's style. The CI `black --check .` step fails on every PR that creates a migration because Django's codegen doesn't follow black's formatting rules
- **Additional context:** Same fix pattern already applied for flake8 via `.flake8` config — this brings black in line with that

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [x] CI / tooling change
- [ ] Documentation update
- [ ] Security fix

---

## Related Issues

Fixes recurring CI failure: `black --check` would reformat migration files on every PR

---

## Backend Checklist

- [x] Models: no changes
- [x] Serializers: no changes
- [x] Views: no changes
- [x] URLs: no changes
- [x] All responses use `APIResponse` wrapper
- [x] No raw SQL or unfiltered querysets exposed to unauthenticated users
- [x] `manage.py check` passes locally

---

## Tests

- [x] Verified `black --check .` passes locally after this change

---

## Docs / Notes

`pyproject.toml` is the standard place for black config. The `exclude` regex skips any path containing a `migrations/` or `venv/` directory. Line length set to 119 to match the existing flake8 config.