### PR TITLE
chore: switch timezone configuration from Asia/Kolkata to UTC

### DIFF
--- a/toddy_shop_backend/config/settings.py
+++ b/toddy_shop_backend/config/settings.py
@@ -109,7 +109,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "Asia/Kolkata"
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 


### PR DESCRIPTION
**Description**
This PR updates the backend timezone configuration from Asia/Kolkata to UTC to standardize all timestamp handling across the system.

- Summary of changes:
Changed TIME_ZONE = "Asia/Kolkata" to TIME_ZONE = "UTC" in backend settings.

- Reasoning / motivation:
Prevents timezone-related bugs in scheduling, logs, and cross-region deployments.
Aligns with backend best practices for scalable systems.

- Docs / Notes
Backend now operates fully in UTC
Frontend should handle timezone conversion if displaying local time
Ensure any scheduled jobs or cron logic assumes UTC going forward
All existing timestamp fields must be reviewed and backfilled to UTC

## Related Issues
Closes #19 