### PR TITLE
Add: Whitenoise dependency to pyproject.toml

### DIFF
--- a/toddy_shop_backend/pyproject.toml
+++ b/toddy_shop_backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django-filter>=24.0",
     "Pillow>=11.0.0",
     "drf-spectacular>=0.29.0",
+    "whitenoise>=6.0.0"
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description

This PR adds **WhiteNoise** to the project dependencies to enable efficient static file serving directly from the Django application in production environments.

* **Summary of changes:**

  * Added `whitenoise` to `pyproject.toml` dependencies


* **Reasoning / motivation:**

  * Simplifies deployment for environments like Render, Railway, or small VPS setups
  * Eliminates the need for separate static file infrastructure in early-stage deployments
  * Provides gzip compression and caching support out of the box

* **Additional context:**

  * This change is dependency-level only; middleware/config integration (if required) will be handled separately
  * Safe for MVP and small-scale production usage

---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor / code cleanup
* [ ] Performance improvement
* [ ] CI / tooling change
* [ ] Documentation update
* [ ] Security fix

---

## Related Issues

Closes #62 

## Screenshots

> Not applicable (backend-only dependency update)

---

## Docs / Notes

* WhiteNoise requires middleware setup in `settings.py` for full functionality:

  * Add `WhiteNoiseMiddleware` after `SecurityMiddleware`
* Recommended to enable:

  * `STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"`

