### PR TITLE
fix: add missing whitenoise dependency to pyproject.toml

### DIFF
--- a/toddy_shop_backend/pyproject.toml
+++ b/toddy_shop_backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django-filter>=24.0",
     "Pillow>=11.0.0",
     "drf-spectacular>=0.29.0",
+    "whitenoise>=6.0.0",
 ]
 
 [tool.black]

--- a/toddy_shop_backend/uv.lock
+++ b/toddy_shop_backend/uv.lock
@@ -146,6 +146,7 @@ dependencies = [
     { name = "djangorestframework-simplejwt" },
     { name = "drf-spectacular" },
     { name = "pillow" },
+    { name = "whitenoise" },
 ]
 
 [package.metadata]
@@ -157,6 +158,7 @@ requires-dist = [
     { name = "djangorestframework-simplejwt", specifier = ">=5.3.1" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "whitenoise", specifier = ">=6.12.0" },
 ]
 
 [[package]]
@@ -412,4 +414,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]


### PR DESCRIPTION
## Description

Adds the missing `whitenoise` package to `pyproject.toml` so that `uv sync` installs it correctly during project setup.

- **Summary of changes:** Added `"whitenoise>=6.0.0"` to the `dependencies` list in `toddy_shop_backend/pyproject.toml` and updated `uv.lock`.
- **Reasoning / motivation:** `whitenoise` is used in `config/settings.py` as a WSGI middleware (`whitenoise.middleware.WhiteNoiseMiddleware`) and as the static files storage backend (`whitenoise.storage.CompressedManifestStaticFilesStorage`), but it was not declared as a dependency. Running `uv sync` skips it, causing every new contributor to hit a `ModuleNotFoundError` and a server crash immediately after setup.
- **Additional context:** This was discovered while following the setup steps in `CONTRIBUTING.md`. Reproducible on a clean clone.

---

## Type of Change

- [x] Bug fix

---

## Related Issues

Closes #62

---

## Backend Checklist

- [x] `manage.py check` passes locally

> Not applicable — no models, serializers, views, or URLs were changed. This is a dependency declaration fix only.

---

## Tests

- [x] Tested happy path and edge cases manually

```bash
# Steps to reproduce the fix:
git clone https://github.com/KERALACODERSCAFE/Kerala-toddy-finder.git
cd Kerala-toddy-finder/toddy_shop_backend
uv venv
.venv\Scripts\activate
uv sync
uv run python manage.py migrate
uv run python manage.py runserver
# ✅ Server starts successfully at http://127.0.0.1:8000
```

---

## Docs / Notes

Single line fix in `pyproject.toml`:
```toml
"whitenoise>=6.0.0",
```