### PR TITLE
feat: add cn() utility for safe Tailwind class merging

### DIFF
--- a/toddy_shop_frontend/package-lock.json
+++ b/toddy_shop_frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "toddy_shop_frontend",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "next": "16.2.4",
         "react": "19.2.5",
-        "react-dom": "19.2.5"
+        "react-dom": "19.2.5",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2555,6 +2557,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5903,6 +5914,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/toddy_shop_frontend/package.json
+++ b/toddy_shop_frontend/package.json
@@ -9,9 +9,11 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "16.2.4",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/toddy_shop_frontend/src/features/shops/components/ShopCard.tsx
+++ b/toddy_shop_frontend/src/features/shops/components/ShopCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 interface Shop {
   id: string;
@@ -26,7 +27,12 @@ export function ShopCard({ shop }: { shop: Shop }) {
         />
         {shop.badge && (
           <div
-            className={`absolute top-4 right-4 ${shop.badgeColor} text-white px-3 py-1 rounded-full text-[10px] font-bold flex items-center gap-1 uppercase tracking-wider`}
+            className={cn(
+              "absolute top-4 right-4",
+              "text-white px-3 py-1 rounded-full",
+              "text-[10px] font-bold flex items-center gap-1 uppercase tracking-wider",
+              shop.badgeColor
+            )}
           >
             {shop.badge === "Hygiene Verified" && (
               <span
@@ -49,10 +55,10 @@ export function ShopCard({ shop }: { shop: Shop }) {
         </div>
         <p className="text-stone-500 text-sm mb-4">{shop.district}</p>
         <div className="flex flex-wrap gap-2 mb-6">
-          <span className="leaf-chip bg-secondary/10 text-secondary px-3 py-1 text-[11px] font-bold">
+          <span className={cn("leaf-chip px-3 py-1 text-[11px] font-bold", "bg-secondary/10 text-secondary")}>
             {shop.district.toUpperCase()}
           </span>
-          <span className="leaf-chip bg-primary/5 text-primary px-3 py-1 text-[11px] font-bold">
+          <span className={cn("leaf-chip px-3 py-1 text-[11px] font-bold", "bg-primary/5 text-primary")}>
             {shop.tag}
           </span>
         </div>

--- a/toddy_shop_frontend/src/lib/utils.ts
+++ b/toddy_shop_frontend/src/lib/utils.ts
@@ -1,0 +1,16 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merges Tailwind CSS class names safely, resolving conflicts.
+ *
+ * - Uses `clsx` for conditional class joining (handles strings, arrays, objects)
+ * - Uses `tailwind-merge` to deduplicate conflicting Tailwind utilities
+ *
+ * @example
+ * cn("px-4 py-2", isActive && "bg-primary", "text-white")
+ * cn("text-sm", variant === "lg" && "text-lg") // → "text-lg" (conflict resolved)
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION

## Description

Introduces a `cn()` utility helper to the frontend for safe and conflict-free Tailwind CSS class merging. This is a standard pattern used across modern Next.js/React codebases (including shadcn/ui, v0, etc.).

- **Summary of changes:** Added `clsx` and `tailwind-merge` as dependencies. Created `src/lib/utils.ts` exporting a `cn()` helper. Refactored `ShopCard.tsx` to use `cn()` for dynamic class composition.
- **Reasoning / motivation:** The project currently uses raw template literals (e.g. `` `${shop.badgeColor} text-white px-3` ``) for dynamic class merging. This approach can silently produce conflicting Tailwind classes (e.g. `px-2 px-4` both applying). The `cn()` helper solves this by combining `clsx` (conditional logic) with `tailwind-merge` (conflict resolution), making class composition safer and more readable.
- **Additional context:** This is a purely additive, non-breaking change. The `cn()` helper is now available for all future components to use via `import { cn } from "@/lib/utils"`.

---

## Type of Change

- [x] New feature
- [x] Refactor / code cleanup

---

## Related Issues

Closes #66

---

## Backend Checklist

> Not applicable — this is a frontend-only change. No backend modifications were made.

---

## Tests

- [x] Tested happy path and edge cases manually

```bash
# Ran the dev server and verified ShopCard renders correctly
cd toddy_shop_frontend
npm run dev
# Visited http://localhost:3000 — Featured Shops section renders
# with correct badge colors and tags, no visual regression.
```

---

## Screenshots

> *(No visual change — this is a code quality refactor. The UI looks identical before and after.)*

---

## Docs / Notes

New utility available for all components going forward:

```ts
import { cn } from "@/lib/utils";

// Usage:
className={cn("base-classes", condition && "conditional-class", variantClass)}
```