### PR TITLE
feat: build /shops/[id] shop detail page

### DIFF
--- a/toddy_shop_frontend/src/app/shops/[id]/page.tsx
+++ b/toddy_shop_frontend/src/app/shops/[id]/page.tsx
@@ -1,24 +1,39 @@
-export default async function ShopDetail({
+import { SHOP_DETAILS } from "@/features/shops/data";
+import { ShopDetailPage, ShopNotFound } from "@/features/shops/components/ShopDetailPage";
+
+export async function generateStaticParams() {
+  return SHOP_DETAILS.map((shop) => ({ id: shop.id }));
+}
+
+export async function generateMetadata({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const shop = SHOP_DETAILS.find((s) => s.id === id);
 
-  return (
-    <div className="max-w-7xl mx-auto py-20 px-8">
-      <div className="text-center">
-        <span className="material-symbols-outlined text-6xl text-primary mb-4">
-          storefront
-        </span>
-        <h1 className="font-[family-name:var(--font-heading)] text-4xl text-primary font-semibold mb-4">
-          Shop: {id}
-        </h1>
-        <p className="text-stone-600 text-lg">
-          Detailed shop page coming soon. This will show menus, reviews, photos,
-          and directions.
-        </p>
-      </div>
-    </div>
-  );
+  if (!shop) {
+    return { title: "Shop Not Found | Shaap" };
+  }
+
+  return {
+    title: `${shop.name} — ${shop.district} | Shaap`,
+    description: shop.tagline,
+  };
+}
+
+export default async function ShopDetailRoute({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const shop = SHOP_DETAILS.find((s) => s.id === id);
+
+  if (!shop) {
+    return <ShopNotFound id={id} />;
+  }
+
+  return <ShopDetailPage shop={shop} />;
 }

--- a/toddy_shop_frontend/src/features/shops/components/ShopDetailPage.tsx
+++ b/toddy_shop_frontend/src/features/shops/components/ShopDetailPage.tsx
@@ -1,0 +1,271 @@
+import Image from "next/image";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { ShopDetail } from "@/features/shops/data";
+
+// ─── Back Button ─────────────────────────────────────────────────────────────
+function BackButton() {
+  return (
+    <Link
+      href="/"
+      className="inline-flex items-center gap-2 text-primary font-bold hover:opacity-70 transition-opacity mb-6"
+    >
+      <span className="material-symbols-outlined">arrow_back</span>
+      Back to Home
+    </Link>
+  );
+}
+
+// ─── Hero Banner ─────────────────────────────────────────────────────────────
+function ShopHero({ shop }: { shop: ShopDetail }) {
+  return (
+    <div className="relative w-full h-72 md:h-96 rounded-3xl overflow-hidden mb-8">
+      <Image
+        src={shop.image}
+        alt={shop.alt}
+        fill
+        priority
+        className="object-cover"
+        sizes="100vw"
+      />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+      <div className="absolute bottom-0 left-0 p-8">
+        {shop.badge && (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 px-3 py-1 rounded-full",
+              "text-white text-[11px] font-bold uppercase tracking-wider mb-3",
+              shop.badgeColor
+            )}
+          >
+            <span
+              className="material-symbols-outlined text-[12px]"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              verified
+            </span>
+            {shop.badge}
+          </span>
+        )}
+        <h1 className="font-[family-name:var(--font-heading)] text-4xl md:text-5xl text-white font-semibold">
+          {shop.name}
+        </h1>
+        <p className="text-white/80 mt-1 text-sm">{shop.tagline}</p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Info Bar ─────────────────────────────────────────────────────────────────
+function ShopInfoBar({ shop }: { shop: ShopDetail }) {
+  return (
+    <div className="flex flex-wrap items-center gap-6 mb-8 pb-8 border-b border-tertiary-fixed">
+      {/* Rating */}
+      <div className="flex items-center gap-2">
+        <span className="text-secondary font-bold text-2xl">{shop.rating} ★</span>
+        <span className="text-stone-500 text-sm">({shop.totalReviews} reviews)</span>
+      </div>
+
+      {/* Status */}
+      <span
+        className={cn(
+          "leaf-chip px-3 py-1 text-[11px] font-bold uppercase tracking-wider",
+          shop.isOpen
+            ? "bg-green-100 text-green-700"
+            : "bg-red-100 text-red-700"
+        )}
+      >
+        {shop.isOpen ? "Open Now" : "Closed"}
+      </span>
+
+      {/* Location */}
+      <span className="flex items-center gap-1 text-stone-600 text-sm">
+        <span className="material-symbols-outlined text-[16px] text-primary">location_on</span>
+        {shop.location}
+      </span>
+
+      {/* Est. */}
+      <span className="flex items-center gap-1 text-stone-600 text-sm">
+        <span className="material-symbols-outlined text-[16px] text-primary">history</span>
+        Est. {shop.established}
+      </span>
+
+      {/* Phone */}
+      <a
+        href={`tel:${shop.phone}`}
+        className="flex items-center gap-1 text-primary font-bold text-sm hover:opacity-70 transition-opacity"
+      >
+        <span className="material-symbols-outlined text-[16px]">call</span>
+        {shop.phone}
+      </a>
+    </div>
+  );
+}
+
+// ─── Amenities ────────────────────────────────────────────────────────────────
+function Amenities({ shop }: { shop: ShopDetail }) {
+  return (
+    <div className="bg-surface-container-low rounded-2xl p-6 mb-6">
+      <h2 className="font-[family-name:var(--font-heading)] text-xl text-primary font-semibold mb-4">
+        Amenities
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {shop.amenities.map((a) => (
+          <div
+            key={a.label}
+            className="flex items-center gap-2 text-stone-700 text-sm"
+          >
+            <span className="material-symbols-outlined text-[18px] text-primary">{a.icon}</span>
+            {a.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Opening Hours ────────────────────────────────────────────────────────────
+function OpeningHours({ shop }: { shop: ShopDetail }) {
+  return (
+    <div className="bg-surface-container-low rounded-2xl p-6 mb-6">
+      <h2 className="font-[family-name:var(--font-heading)] text-xl text-primary font-semibold mb-4">
+        Opening Hours
+      </h2>
+      <div className="space-y-2">
+        {shop.hours.map((h) => (
+          <div key={h.day} className="flex justify-between text-sm">
+            <span className="text-stone-600">{h.day}</span>
+            <span
+              className={cn(
+                "font-bold",
+                h.time === "Closed" ? "text-red-600" : "text-primary"
+              )}
+            >
+              {h.time}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Menu ─────────────────────────────────────────────────────────────────────
+function Menu({ shop }: { shop: ShopDetail }) {
+  return (
+    <section className="mb-10">
+      <h2 className="font-[family-name:var(--font-heading)] text-2xl text-primary font-semibold mb-6">
+        Menu
+      </h2>
+      <div className="space-y-6">
+        {shop.menu.map((section) => (
+          <div key={section.category}>
+            <h3 className="text-[11px] font-bold tracking-[3px] uppercase text-stone-500 mb-3">
+              {section.category}
+            </h3>
+            <div className="space-y-3">
+              {section.items.map((item) => (
+                <div
+                  key={item.name}
+                  className="flex justify-between items-start bg-white border border-tertiary-fixed rounded-xl px-5 py-4 hover:border-secondary/40 transition-colors"
+                >
+                  <div>
+                    <p className="font-bold text-primary">{item.name}</p>
+                    <p className="text-stone-500 text-sm mt-0.5">{item.description}</p>
+                  </div>
+                  <span className="font-bold text-secondary ml-6 shrink-0">{item.price}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── Reviews ─────────────────────────────────────────────────────────────────
+function Reviews({ shop }: { shop: ShopDetail }) {
+  return (
+    <section>
+      <h2 className="font-[family-name:var(--font-heading)] text-2xl text-primary font-semibold mb-6">
+        Community Reviews
+      </h2>
+      <div className="space-y-4">
+        {shop.reviews.map((review) => (
+          <div
+            key={review.id}
+            className="bg-white border border-tertiary-fixed rounded-2xl p-6"
+          >
+            <div className="flex items-start gap-4">
+              <div className="w-10 h-10 rounded-full bg-primary text-white flex items-center justify-center font-bold text-sm shrink-0">
+                {review.avatar}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between flex-wrap gap-2">
+                  <span className="font-bold text-primary">{review.author}</span>
+                  <span className="text-stone-400 text-xs">{review.date}</span>
+                </div>
+                <div className="text-secondary font-bold text-sm my-1">
+                  {"★".repeat(review.rating)}
+                  {"☆".repeat(5 - review.rating)}
+                </div>
+                <p className="text-stone-600 text-sm leading-relaxed">{review.text}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── Not Found ────────────────────────────────────────────────────────────────
+function ShopNotFound({ id }: { id: string }) {
+  return (
+    <div className="max-w-7xl mx-auto py-20 px-8 text-center">
+      <span className="material-symbols-outlined text-6xl text-stone-300 mb-4">storefront</span>
+      <h1 className="font-[family-name:var(--font-heading)] text-3xl text-primary font-semibold mb-3">
+        Shop not found
+      </h1>
+      <p className="text-stone-500 mb-8">
+        No shop found with the ID &quot;{id}&quot;.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-xl font-bold hover:bg-primary/90 transition-colors"
+      >
+        <span className="material-symbols-outlined">arrow_back</span>
+        Back to Home
+      </Link>
+    </div>
+  );
+}
+
+// ─── Main Export ──────────────────────────────────────────────────────────────
+export function ShopDetailPage({ shop }: { shop: ShopDetail }) {
+  return (
+    <div className="max-w-7xl mx-auto py-10 px-6 md:px-8">
+      <BackButton />
+      <ShopHero shop={shop} />
+      <ShopInfoBar shop={shop} />
+
+      {/* Two-column layout on desktop */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Left: Menu + Reviews */}
+        <div className="lg:col-span-2">
+          <Menu shop={shop} />
+          <Reviews shop={shop} />
+        </div>
+
+        {/* Right: Sidebar */}
+        <div>
+          <Amenities shop={shop} />
+          <OpeningHours shop={shop} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { ShopNotFound };

--- a/toddy_shop_frontend/src/features/shops/data.ts
+++ b/toddy_shop_frontend/src/features/shops/data.ts
@@ -1,0 +1,258 @@
+export const SHOP_DETAILS = [
+  {
+    id: "mullapanthal",
+    name: "Mullapanthal",
+    tagline: "A heritage taproom tucked in the heart of Kottayam's backwaters",
+    district: "Kottayam",
+    location: "Vaikom Road, Kottayam",
+    rating: 4.9,
+    totalReviews: 312,
+    badge: "Hygiene Verified",
+    badgeColor: "bg-green-600",
+    tag: "OPEN NOW",
+    isOpen: true,
+    phone: "+91 94470 12345",
+    established: "1978",
+    image:
+      "https://lh3.googleusercontent.com/aida-public/AB6AXuBDtRKnc2i9k7SEwueHB4tGtUJE4H7JgA8p6AWjdXjSEhsSSejTcjkfN6Z99ftEZ5ackKKtygL8KJZPjVCNfS_5cOb2K12dNfkkD9XlCpWLC5h8eOi1hzvnHAfmVJMcMu2n64nL8KULjhGKjEk2KYA_wSFoM4crYIX3Ff8P1YrdmwMzjjkwq1LjMIlXYhGQnLzySPW9Zv86vBoWJibZapYx_KOoNAzeiXqpKE5GOrdSIPRfdIodOik4xZm28U8GHHIIRJRpJPsbMykY",
+    alt: "Traditional thatched roof toddy shop in a lush coconut grove",
+    hours: [
+      { day: "Monday – Friday", time: "10:00 AM – 10:00 PM" },
+      { day: "Saturday", time: "9:00 AM – 11:00 PM" },
+      { day: "Sunday", time: "9:00 AM – 10:00 PM" },
+    ],
+    amenities: [
+      { icon: "local_parking", label: "Parking" },
+      { icon: "wifi", label: "Free Wi-Fi" },
+      { icon: "ac_unit", label: "AC Room" },
+      { icon: "outdoor_grill", label: "Open Air Seating" },
+      { icon: "wc", label: "Clean Restrooms" },
+      { icon: "payments", label: "UPI Accepted" },
+    ],
+    menu: [
+      {
+        category: "Toddy",
+        items: [
+          { name: "Fresh Sweet Toddy", price: "₹60", description: "Freshly tapped, mildly sweet, best before noon" },
+          { name: "Fermented Toddy", price: "₹80", description: "Classic afternoon toddy with a sharp kick" },
+        ],
+      },
+      {
+        category: "Seafood",
+        items: [
+          { name: "Karimeen Pollichathu", price: "₹320", description: "Pearl spot wrapped in banana leaf with Kerala masala" },
+          { name: "Prawns Fry", price: "₹280", description: "Crispy fried prawns with coconut oil and green chillies" },
+          { name: "Fish Curry", price: "₹180", description: "Traditional red fish curry cooked in earthen pot" },
+        ],
+      },
+      {
+        category: "Meat",
+        items: [
+          { name: "Beef Roast", price: "₹220", description: "Slow cooked beef with coconut slivers and curry leaves" },
+          { name: "Duck Roast", price: "₹280", description: "Kerala-style duck in thick spicy brown gravy" },
+          { name: "Chicken Curry", price: "₹200", description: "Country chicken in roasted coconut gravy" },
+        ],
+      },
+      {
+        category: "Sides",
+        items: [
+          { name: "Kappa (Tapioca)", price: "₹60", description: "Steamed tapioca served with chutney" },
+          { name: "Puttu & Kadala", price: "₹80", description: "Steamed rice cake with black chickpea curry" },
+        ],
+      },
+    ],
+    reviews: [
+      {
+        id: 1,
+        author: "Vishnu Raj",
+        avatar: "VR",
+        rating: 5,
+        date: "Mar 2024",
+        text: "Best Karimeen Pollichathu I've had in Kottayam. The toddy is fresh and the ambience is pure Kerala nostalgia. A must-visit for anyone passing through.",
+      },
+      {
+        id: 2,
+        author: "Meera Nair",
+        avatar: "MN",
+        rating: 5,
+        date: "Feb 2024",
+        text: "Came here with family. The fish curry is outstanding — perfectly balanced spices. The staff is warm and the hygiene is genuinely top-notch.",
+      },
+      {
+        id: 3,
+        author: "Arun Thomas",
+        avatar: "AT",
+        rating: 4,
+        date: "Jan 2024",
+        text: "Authentic toddy shop experience. The beef roast is exceptional. Parking can be a little tight on weekends, but worth the visit.",
+      },
+    ],
+  },
+  {
+    id: "karimpumkala",
+    name: "Karimpumkala",
+    tagline: "Famous for its backwater views and legendary Karimeen preparation",
+    district: "Alappuzha",
+    location: "Kainakary, Alappuzha",
+    rating: 4.8,
+    totalReviews: 267,
+    badge: "Top Rated",
+    badgeColor: "bg-primary-container",
+    tag: "FAMOUS FOR FOOD",
+    isOpen: true,
+    phone: "+91 94470 23456",
+    established: "1985",
+    image:
+      "https://lh3.googleusercontent.com/aida-public/AB6AXuAJu8Bvwb_h-7hVTXzQFamXklqT_2UuLbWLgpOTZK0DtmB1VYWa0A1ttTWVAA8tuOxoRhVt8kx_aJ9OLFaIUem6Md_mMoOJTikqY27G2ZGLp0Q805mIy2g8232EeBq6QKLc38vF7neFvviE35kcHoULlEQXPZsUgLSD3lYFgt7ndr7PUo3WfgxhLwlHFVjFpEtHuEsf3Nyql-Y_oYqiTRJ7M85Hpvog4DXU0BwSsfakArhwWh_DH2sHRm78Xh9b_aHqkePsOQ02G8c",
+    alt: "Aerial view of traditional backwater toddy shop with red tiled roof",
+    hours: [
+      { day: "Monday – Saturday", time: "10:00 AM – 9:30 PM" },
+      { day: "Sunday", time: "Closed" },
+    ],
+    amenities: [
+      { icon: "directions_boat", label: "Boat Access" },
+      { icon: "outdoor_grill", label: "Open Air Seating" },
+      { icon: "payments", label: "UPI Accepted" },
+      { icon: "wc", label: "Clean Restrooms" },
+    ],
+    menu: [
+      {
+        category: "Toddy",
+        items: [
+          { name: "Sweet Toddy", price: "₹60", description: "Morning tapped, mildly sweet" },
+          { name: "Fermented Toddy", price: "₹80", description: "Afternoon strength toddy" },
+        ],
+      },
+      {
+        category: "Seafood",
+        items: [
+          { name: "Karimeen Pollichathu", price: "₹340", description: "Signature dish — rivalling any restaurant in Kerala" },
+          { name: "Crab Roast", price: "₹380", description: "Mud crab in spicy masala, best in Alappuzha" },
+        ],
+      },
+    ],
+    reviews: [
+      {
+        id: 1,
+        author: "Sree Kumar",
+        avatar: "SK",
+        rating: 5,
+        date: "Apr 2024",
+        text: "The Karimeen here is the best I've ever had. Came by boat — worth every minute of the journey.",
+      },
+      {
+        id: 2,
+        author: "Divya Menon",
+        avatar: "DM",
+        rating: 5,
+        date: "Mar 2024",
+        text: "Authentic backwater experience. The setting by the canal is breathtaking. Crab roast is a must order.",
+      },
+    ],
+  },
+  {
+    id: "puzhayoram",
+    name: "Puzhayoram",
+    tagline: "Riverside dining with the freshest catch from Periyar every morning",
+    district: "Ernakulam",
+    location: "Nettoor, Ernakulam",
+    rating: 4.7,
+    totalReviews: 198,
+    badge: null,
+    badgeColor: "",
+    tag: "RIVER VIEW",
+    isOpen: false,
+    phone: "+91 94470 34567",
+    established: "1992",
+    image:
+      "https://lh3.googleusercontent.com/aida-public/AB6AXuDQ73YOD94h6groYgqNCi1NHTRapRDwQgptbzZr_0GF8Y3wHaPJcau_twmPalbxA04lxKuOgsORakqWQ0jMG8FqDJ5PdBNilyCgyd6yW0OSu-DavnAHFqT88GYGnjp1jwsA_2ijjxomiCwNxDaF1bibjRb5Amqiu6fnrAoP7Lry66Tscr8w5soarY8y6wntrvCTp294qhPkBM5P3ulR7vsK7TEfUZt3l95m-atUn4buSF5ChD6UyMVPzzjDAXHqp0JRSe3VLOVrRUs",
+    alt: "Interior of a rustic toddy shop with wooden benches and palm leaf decor",
+    hours: [
+      { day: "Tuesday – Sunday", time: "11:00 AM – 9:00 PM" },
+      { day: "Monday", time: "Closed" },
+    ],
+    amenities: [
+      { icon: "local_parking", label: "Parking" },
+      { icon: "outdoor_grill", label: "River View Seating" },
+      { icon: "payments", label: "UPI Accepted" },
+    ],
+    menu: [
+      {
+        category: "Toddy",
+        items: [
+          { name: "Sweet Toddy", price: "₹60", description: "River-cooled, freshly tapped" },
+        ],
+      },
+      {
+        category: "Seafood",
+        items: [
+          { name: "River Fish Curry", price: "₹160", description: "Daily fresh catch from Periyar" },
+          { name: "Prawns Roast", price: "₹260", description: "Dry roasted Kerala prawns" },
+        ],
+      },
+    ],
+    reviews: [
+      {
+        id: 1,
+        author: "Anoop Varghese",
+        avatar: "AV",
+        rating: 5,
+        date: "Feb 2024",
+        text: "The river view alone is worth the visit. Fish curry is freshness personified.",
+      },
+    ],
+  },
+  {
+    id: "kiliroor",
+    name: "Kiliroor Shaap",
+    tagline: "Over four decades of unbroken toddy shop tradition in old Kottayam",
+    district: "Kottayam",
+    location: "Kiliroor, Kottayam",
+    rating: 4.6,
+    totalReviews: 145,
+    badge: null,
+    badgeColor: "",
+    tag: "OLD HERITAGE",
+    isOpen: true,
+    phone: "+91 94470 45678",
+    established: "1971",
+    image:
+      "https://lh3.googleusercontent.com/aida-public/AB6AXuBebhMv23641swdu2vkIIXss1Z0c4GBo7JRyaGVF6_lpLN8_R-7gcKL62glqGN4Ie4v56nm08aqHKzM609BJKwVGVni80otA9w5FtMAsi5gyH3rC6FpmRBF8e-jAh8OIWb9flNCjMkWPNisIVAyppsfnue7zAneOkrnxQ45TADVy_6uVImrnH0M317yjZGTvIiB01F6Qg0Z3rehDxXuRmCLtIjU0-N39UWpwroRFq4yZzWSfi2_9QzAlAY9xvhiRQI7G-SVpUtit1Q",
+    alt: "Close up of a traditional earthen pot with toddy and spices",
+    hours: [
+      { day: "Monday – Sunday", time: "10:00 AM – 9:00 PM" },
+    ],
+    amenities: [
+      { icon: "outdoor_grill", label: "Open Air Seating" },
+      { icon: "payments", label: "Cash Only" },
+      { icon: "wc", label: "Restrooms" },
+    ],
+    menu: [
+      {
+        category: "Toddy",
+        items: [
+          { name: "Traditional Toddy", price: "₹50", description: "Old-school earthen pot toddy" },
+        ],
+      },
+      {
+        category: "Food",
+        items: [
+          { name: "Kappa & Meen Curry", price: "₹120", description: "Classic tapioca with spicy fish curry" },
+          { name: "Beef Fry", price: "₹180", description: "Dry fried beef with coconut slivers" },
+        ],
+      },
+    ],
+    reviews: [
+      {
+        id: 1,
+        author: "Rajan Pillai",
+        avatar: "RP",
+        rating: 5,
+        date: "Jan 2024",
+        text: "The oldest toddy shop I've been to. The earthen pot toddy takes you back in time. A piece of living history.",
+      },
+    ],
+  },
+] as const;
+
+export type ShopDetail = (typeof SHOP_DETAILS)[number];


### PR DESCRIPTION
Description
Implements the /shops/[id] dynamic route which was previously a "coming soon" placeholder. Each shop now has a fully featured detail page built from static data, following the existing features/*/data.ts pattern used by explore and community features.

Summary of changes: Added src/features/shops/data.ts with rich per-shop data (menu, reviews, amenities, hours, phone, tagline) for all 4 featured shops. Added src/features/shops/components/ShopDetailPage.tsx composed of focused sub-components (hero banner, info bar, menu, reviews, amenities, opening hours, 404 fallback). Updated src/app/shops/[id]/page.tsx replacing the stub with the real page — includes generateStaticParams and generateMetadata for SEO.
Reasoning / motivation: The ShopCard "View Details" button already linked to /shops/:id but landed on a placeholder. This makes that flow fully functional end-to-end for the first time.
Additional context: Data is static for now, consistent with how explore/data.ts and community/data.ts are structured. When the Django backend API is ready, data.ts can be swapped for API calls without touching the component layer.