### PR TITLE
docs: align CONTRIBUTING with Python, Django, and Node requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,10 @@
 Thank you for your interest in contributing to the Kerala Toddy Finder project! We welcome contributions from everyone. Below are guidelines to help you get started.
 
 ## Requirements
-- Python 3.x
-- Django 3.x
-- Node.js 14.x or higher
-- npm 6.x or higher
+- **Python** 3.12 or higher (`requires-python` in `toddy_shop_backend/pyproject.toml`)
+- **Django** 6.0 or higher (declared in `pyproject.toml`; `requirements.txt` pins exact versions)
+- **Node.js** 20.9 or higher (Next.js 16 engine requirement)
+- **npm** 9 or higher recommended (typical for current Node 20+ installs)
 
 ## Setup Instructions
 ### Django Backend
@@ -50,10 +50,12 @@ Thank you for your interest in contributing to the Kerala Toddy Finder project! 
    ```bash
    npm install
    ```
-3. Start the frontend server:
+3. Start the development server:
    ```bash
-   npm start
+   npm run dev
    ```
+
+   For a production build locally, run `npm run build` then `npm start` (`next start`).
 
 ## Code Standards
 - **Python**: Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/). We use `flake8` for linting and `pre-commit` hooks to ensure standards are met before committing.


### PR DESCRIPTION
## Description

Updates `CONTRIBUTING.md` to align environment requirements and frontend setup with the current repo.

- Python 3.12+, Django 6
- Node 20.9+ (Next.js 16)
- Updated frontend workflow to use `npm run dev` for local development
- Added note on optional production flow (`build` + `start`)
- Removed outdated references (Django 3, Node 14, npm 6)

## Reasoning / Motivation

Previous documentation was outdated and could mislead contributors (incorrect runtime versions and dev commands). This update ensures contributors can set up and run the project correctly.

## Scope

- Documentation only
- No code or dependency changes

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] CI / tooling change
- [x] Documentation update
- [ ] Security fix

---

## Backend Checklist

**N/A — docs-only PR; no backend changes.**

---

## Tests

- [x] Verified documentation accuracy against:
  - `pyproject.toml` (Python + Django versions)
  - `requirements.txt`
  - `package.json` scripts (`dev`, `build`, `start`)
  - `package-lock.json` (Node engine)


---

## Screenshots

N/A — documentation-only; no UI changes.

---

## Docs / Notes

- File updated: `CONTRIBUTING.md`
- Branch: `docs/contributing-requirements`