### PR TITLE
Changed the copyright from 2024 to 2026

### DIFF
--- a/toddy_shop_frontend/src/components/layout/Footer.tsx
+++ b/toddy_shop_frontend/src/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ export function Footer() {
             Shaap
           </div>
           <p className="text-stone-600 text-sm">
-            &copy; 2024 Kerala Shaap Discovery. Heritage preservation through
+            &copy; 2026 Kerala Shaap Discovery. Heritage preservation through
             community.
           </p>
         </div>


### PR DESCRIPTION
## Description

The copyrights are belongs to 2024 not 2026, so I changed it to 2026.

- **Summary of changes:**
Copyright year from 2024 to 2026

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] CI / tooling change
- [ ] Documentation update
- [ ] Security fix

---

## Screenshots

<img width="1919" height="344" alt="image" src="https://github.com/user-attachments/assets/d0f23d77-ceb5-4a37-8f6b-41d0138336c8" />

@DanBrown47 @AravindRaj-97