### PR TITLE
feat: integrate dynamic Leaflet map on /explore with premium floating UI overlay

### DIFF
--- a/toddy_shop_frontend/package-lock.json
+++ b/toddy_shop_frontend/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "d3-geo": "^3.1.1",
+        "leaflet": "^1.9.4",
         "lucide-react": "^1.14.0",
         "next": "16.2.4",
         "react": "19.2.5",
         "react-dom": "19.2.5",
+        "react-leaflet": "^5.0.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -1304,6 +1306,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4750,6 +4763,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5674,6 +5693,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/toddy_shop_frontend/package.json
+++ b/toddy_shop_frontend/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "d3-geo": "^3.1.1",
+    "leaflet": "^1.9.4",
     "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "react-leaflet": "^5.0.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/toddy_shop_frontend/src/app/explore/page.tsx
+++ b/toddy_shop_frontend/src/app/explore/page.tsx
@@ -1,11 +1,4 @@
-import Image from "next/image";
-import Link from "next/link";
-import {
-  MAP_MARKERS,
-  FEATURED_EXPLORE_SHOP,
-  RECOMMENDED_SHOPS,
-  MAP_IMAGE,
-} from "@/features/explore/data";
+import ExploreClient from "@/features/explore/ExploreClient";
 
 export const metadata = {
   title: "Explore Shops | Toddy Finder",
@@ -14,189 +7,27 @@ export const metadata = {
 
 export default function ExplorePage() {
   return (
-    <div className="relative flex overflow-hidden" style={{ height: "calc(100vh - 72px)" }}>
-      {/* Map Area */}
-      <div className="relative flex-grow h-full bg-surface-container overflow-hidden">
-        <Image
-          src={MAP_IMAGE}
-          alt="Topographical map of Kerala backwaters with illustrated palm trees and waterway patterns"
-          fill
-          className="object-cover opacity-60"
-          priority
-        />
+    <main className="relative h-screen w-full overflow-hidden">
+      
+      {/* MAP */}
+      <ExploreClient />
 
-        {/* Map Markers */}
-        {MAP_MARKERS.map((marker) => (
-          <div
-            key={marker.id}
-            className="absolute group cursor-pointer"
-            style={{ top: marker.top, left: marker.left }}
-          >
-            <div
-              className={`${
-                marker.color === "primary"
-                  ? "bg-primary-container text-on-primary-container"
-                  : "bg-secondary text-on-secondary"
-              } p-2 rounded-full shadow-lg border-2 border-surface flex items-center justify-center transition-transform group-hover:scale-110`}
-            >
-              <span
-                className="material-symbols-outlined text-[20px]"
-                style={{ fontVariationSettings: "'FILL' 1" }}
-              >
-                {marker.icon}
-              </span>
-            </div>
-            <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-surface/85 backdrop-blur-sm border border-outline-variant px-3 py-1 rounded shadow-sm opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
-              <span className="font-[family-name:var(--font-heading)] text-sm font-semibold">
-                {marker.name}
-              </span>
-            </div>
-          </div>
-        ))}
-
-        {/* Floating Search Bar */}
-        <div className="absolute top-8 left-1/2 -translate-x-1/2 w-full max-w-2xl px-4">
-          <div className="bg-surface/85 backdrop-blur-sm shadow-xl border border-outline-variant rounded-full p-2 flex items-center space-x-2">
-            <div className="flex-grow flex items-center px-4">
-              <span className="material-symbols-outlined text-outline">search</span>
-              <input
-                className="bg-transparent border-none focus:ring-0 w-full text-on-surface outline-none ml-2"
-                placeholder="Search by location or shop name..."
-                type="text"
-              />
-            </div>
-            <div className="h-8 w-[1px] bg-outline-variant" />
-            <button className="flex items-center space-x-2 px-4 py-2 hover:bg-surface-container rounded-full transition-colors text-on-surface-variant text-[14px] font-semibold tracking-wider cursor-pointer">
-              <span className="material-symbols-outlined text-sm">tune</span>
-              <span>Filters</span>
-            </button>
-          </div>
-        </div>
-
-        {/* Map Controls */}
-        <div className="absolute bottom-8 right-8 flex flex-col space-y-2">
-          <button className="bg-surface border border-outline-variant p-3 shadow-md rounded-lg hover:bg-surface-container-high transition-colors cursor-pointer">
-            <span className="material-symbols-outlined">my_location</span>
-          </button>
-          <div className="flex flex-col bg-surface border border-outline-variant shadow-md rounded-lg overflow-hidden">
-            <button className="p-3 border-b border-outline-variant hover:bg-surface-container-high transition-colors cursor-pointer">
-              <span className="material-symbols-outlined">add</span>
-            </button>
-            <button className="p-3 hover:bg-surface-container-high transition-colors cursor-pointer">
-              <span className="material-symbols-outlined">remove</span>
-            </button>
+      {/* OVERLAY UI */}
+      <div className="relative z-[10] pointer-events-none">
+        <div className="absolute top-4 left-4 p-4 bg-white/95 dark:bg-slate-900/95 backdrop-blur-md rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800/50 max-w-sm pointer-events-auto">
+          <h1 className="text-xl font-bold font-heading text-[#003e1c] dark:text-emerald-400">Kerala Toddy Finder</h1>
+          <p className="text-xs text-slate-500 mt-1">Discover traditional, authentic toddy shops across Kerala.</p>
+          <div className="mt-4 pt-3 border-t border-slate-100 dark:border-slate-800 flex items-center gap-2">
+            <span className="flex h-2 w-2 relative">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+            </span>
+            <span className="text-xs text-slate-600 dark:text-slate-300 font-semibold">Interactive Map Live</span>
           </div>
         </div>
       </div>
 
-      {/* Side Drawer */}
-      <aside className="w-[400px] bg-surface border-l border-outline-variant flex-col h-full z-10 shadow-2xl hidden md:flex">
-        <div className="p-6 border-b border-outline-variant flex justify-between items-center">
-          <h2 className="font-[family-name:var(--font-heading)] text-2xl font-semibold text-primary">
-            Discover Nearby
-          </h2>
-          <button className="text-outline hover:text-primary transition-colors cursor-pointer">
-            <span className="material-symbols-outlined">
-              keyboard_double_arrow_right
-            </span>
-          </button>
-        </div>
-
-        <div className="flex-grow overflow-y-auto p-6 space-y-8 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-outline [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
-          {/* Featured Shop Card */}
-          <div className="group border border-outline-variant rounded-xl overflow-hidden bg-white transition-all hover:shadow-md">
-            <div className="relative h-48">
-              <Image
-                src={FEATURED_EXPLORE_SHOP.image}
-                alt={FEATURED_EXPLORE_SHOP.alt}
-                fill
-                className="object-cover"
-                sizes="400px"
-              />
-              <div className="absolute top-4 right-4 bg-primary-container text-on-primary-container px-3 py-1 rounded-full text-xs font-semibold tracking-wider">
-                {FEATURED_EXPLORE_SHOP.status}
-              </div>
-            </div>
-            <div className="p-4 space-y-2">
-              <div className="flex justify-between items-start">
-                <h3 className="font-[family-name:var(--font-heading)] text-lg font-semibold">
-                  {FEATURED_EXPLORE_SHOP.name}
-                </h3>
-                <div className="flex items-center text-secondary">
-                  <span
-                    className="material-symbols-outlined text-sm"
-                    style={{ fontVariationSettings: "'FILL' 1" }}
-                  >
-                    star
-                  </span>
-                  <span className="text-sm font-semibold ml-1">
-                    {FEATURED_EXPLORE_SHOP.rating}
-                  </span>
-                </div>
-              </div>
-              <p className="text-on-surface-variant text-sm line-clamp-2">
-                {FEATURED_EXPLORE_SHOP.description}
-              </p>
-              <div className="flex flex-wrap gap-2 pt-2">
-                {FEATURED_EXPLORE_SHOP.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="bg-tertiary-fixed text-tertiary px-2 py-1 rounded text-[10px] font-semibold uppercase tracking-wider"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              <Link
-                href={`/shops/${FEATURED_EXPLORE_SHOP.id}`}
-                className="w-full mt-4 border border-secondary text-secondary py-2 rounded-lg font-semibold text-sm tracking-wider hover:bg-secondary/5 transition-colors flex items-center justify-center"
-              >
-                View Details
-              </Link>
-            </div>
-          </div>
-
-          {/* Recommended List */}
-          <div className="space-y-4">
-            <h4 className="text-outline uppercase tracking-widest text-[10px] font-semibold">
-              Recommended For You
-            </h4>
-            {RECOMMENDED_SHOPS.map((shop) => (
-              <Link
-                key={shop.id}
-                href={`/shops/${shop.id}`}
-                className="flex items-center space-x-4 p-3 rounded-lg hover:bg-surface-container-low cursor-pointer transition-colors border border-transparent hover:border-outline-variant"
-              >
-                <Image
-                  src={shop.image}
-                  alt={shop.alt}
-                  width={64}
-                  height={64}
-                  className="w-16 h-16 object-cover rounded-lg"
-                />
-                <div className="flex-grow">
-                  <h5 className="font-[family-name:var(--font-heading)] text-sm font-semibold">
-                    {shop.name}
-                  </h5>
-                  <p className="text-xs text-on-surface-variant">
-                    {shop.location} &bull; {shop.distance}
-                  </p>
-                </div>
-                <span className="material-symbols-outlined text-outline">
-                  chevron_right
-                </span>
-              </Link>
-            ))}
-          </div>
-        </div>
-
-        <div className="p-6 bg-surface-container-low border-t border-outline-variant">
-          <button className="w-full bg-primary-container text-on-primary-container py-4 rounded-xl font-[family-name:var(--font-heading)] font-semibold flex items-center justify-center space-x-3 shadow-lg active:scale-[0.98] transition-transform cursor-pointer">
-            <span className="material-symbols-outlined">explore</span>
-            <span>Start Heritage Trail</span>
-          </button>
-        </div>
-      </aside>
-    </div>
+    </main>
   );
 }
+

--- a/toddy_shop_frontend/src/app/globals.css
+++ b/toddy_shop_frontend/src/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-
+@import "leaflet/dist/leaflet.css";
 @theme inline {
   /* Colors from DESIGN.md */
   --color-surface: #fcf9f8;

--- a/toddy_shop_frontend/src/features/explore/ExploreClient.tsx
+++ b/toddy_shop_frontend/src/features/explore/ExploreClient.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Dynamically import MapView with ssr: false to prevent "window is not defined" error in SSR
+const MapView = dynamic(() => import("@/features/explore/MapView"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-full w-full bg-[#fcf9f8] flex items-center justify-center dark:bg-slate-900">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-10 h-10 border-4 border-[#003e1c] border-t-transparent rounded-full animate-spin"></div>
+        <p className="text-sm text-slate-600 dark:text-slate-400 font-medium tracking-wide animate-pulse">
+          Loading Toddy Shop Map...
+        </p>
+      </div>
+    </div>
+  ),
+});
+
+export default function ExploreClient() {
+  return (
+    <div className="absolute inset-0 z-0">
+      <MapView />
+    </div>
+  );
+}

--- a/toddy_shop_frontend/src/features/explore/ExploreClient.tsx
+++ b/toddy_shop_frontend/src/features/explore/ExploreClient.tsx
@@ -1,6 +1,57 @@
 "use client";
 
+import { useState } from "react";
 import dynamic from "next/dynamic";
+import { Search, SlidersHorizontal, X, Star, MapPin, Sparkles } from "lucide-react";
+
+// Define the static toddy shops data
+const toddyShops = [
+  {
+    id: 1,
+    name: "Mullapanthal Toddy Shop",
+    locationName: "Tripunithura, Kochi",
+    position: [9.9351, 76.3533] as [number, number],
+    description: "Famous for its spicy duck curry, beef roast, and pure coconut toddy.",
+    rating: 4.7,
+    specialty: "Duck & Beef",
+  },
+  {
+    id: 2,
+    name: "Kadamakkudy Toddy Shop",
+    locationName: "Kadamakkudy Islands, Kochi",
+    position: [10.0528, 76.2482] as [number, number],
+    description: "Located amidst scenic backwaters. Scenic sunsets and fresh sweet toddy.",
+    rating: 4.8,
+    specialty: "Crab & Sweet Toddy",
+  },
+  {
+    id: 3,
+    name: "Nettoor Toddy Shop",
+    locationName: "Nettoor, Ernakulam",
+    position: [9.9248, 76.3150] as [number, number],
+    description: "Traditional lakeside toddy shop serving fiery local delicacies.",
+    rating: 4.4,
+    specialty: "Prawns & Seafood",
+  },
+  {
+    id: 4,
+    name: "Karimpumkala Toddy Shop",
+    locationName: "Pallom, Kottayam",
+    position: [9.5524, 76.5412] as [number, number],
+    description: "Legendary culinary spot since 1952. Outstanding food and toddy.",
+    rating: 4.9,
+    specialty: "Karimeen Pollichathu",
+  },
+  {
+    id: 5,
+    name: "Heritage Alappuzha Toddy Shop",
+    locationName: "Kainakary, Alappuzha",
+    position: [9.4981, 76.3388] as [number, number],
+    description: "Historic shop on the water margins of Kuttanad.",
+    rating: 4.6,
+    specialty: "Beef & Sweet Toddy",
+  },
+];
 
 // Dynamically import MapView with ssr: false to prevent "window is not defined" error in SSR
 const MapView = dynamic(() => import("@/features/explore/MapView"), {
@@ -18,9 +69,257 @@ const MapView = dynamic(() => import("@/features/explore/MapView"), {
 });
 
 export default function ExploreClient() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [activeCenter, setActiveCenter] = useState<[number, number] | null>(null);
+  const [activeShopId, setActiveShopId] = useState<number | null>(null);
+  
+  // Filter States
+  const [selectedRating, setSelectedRating] = useState<number | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [showFilters, setShowFilters] = useState(false);
+
+  // Filter Logic
+  const filteredShops = toddyShops.filter((shop) => {
+    const matchesSearch =
+      shop.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      shop.locationName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      shop.specialty.toLowerCase().includes(searchQuery.toLowerCase());
+
+    const matchesRating = selectedRating ? shop.rating >= selectedRating : true;
+
+    const matchesCategory = selectedCategory
+      ? shop.specialty.toLowerCase().includes(selectedCategory.toLowerCase()) ||
+        shop.description.toLowerCase().includes(selectedCategory.toLowerCase())
+      : true;
+
+    return matchesSearch && matchesRating && matchesCategory;
+  });
+
+  // Suggestions Logic
+  const suggestions = searchQuery
+    ? toddyShops.filter(
+        (shop) =>
+          (shop.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            shop.locationName.toLowerCase().includes(searchQuery.toLowerCase())) &&
+          shop.name.toLowerCase() !== searchQuery.toLowerCase()
+      )
+    : [];
+
+  const handleSelectShop = (shop: typeof toddyShops[0]) => {
+    setSearchQuery(shop.name);
+    setActiveCenter(shop.position);
+    setActiveShopId(shop.id);
+    setShowSuggestions(false);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery("");
+    setActiveShopId(null);
+    setActiveCenter(null);
+    setShowSuggestions(false);
+  };
+
+  const handleResetFilters = () => {
+    setSelectedRating(null);
+    setSelectedCategory(null);
+  };
+
   return (
     <div className="absolute inset-0 z-0">
-      <MapView />
+      {/* MAP */}
+      <MapView
+        shops={filteredShops}
+        activeCenter={activeCenter}
+        activeShopId={activeShopId}
+        onMarkerClick={(shopId) => {
+          setActiveShopId(shopId);
+          const shop = toddyShops.find((s) => s.id === shopId);
+          if (shop) {
+            setActiveCenter(shop.position);
+          }
+        }}
+      />
+
+      {/* FLOATING UI LAYER */}
+      <div className="absolute inset-x-0 top-0 bottom-0 z-[1000] pointer-events-none flex flex-col md:flex-row p-4 gap-4 justify-between md:justify-start items-start">
+        
+        {/* LEFT COLUMN: BRAND CARD & FILTER OPTIONS */}
+        <div className="flex flex-col gap-3 w-full md:w-[320px] pointer-events-auto shrink-0 order-2 md:order-1 mt-auto md:mt-0">
+          
+          {/* BRAND CARD */}
+          <div className="p-4 bg-white/95 dark:bg-slate-900/95 backdrop-blur-md rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800/50">
+            <h1 className="text-xl font-bold font-heading text-[#003e1c] dark:text-emerald-400">Kerala Toddy Finder</h1>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">
+              Discover traditional, authentic toddy shops across Kerala.
+            </p>
+            <div className="mt-4 pt-3 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="flex h-2 w-2 relative">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+                </span>
+                <span className="text-xs text-slate-600 dark:text-slate-300 font-semibold">
+                  {filteredShops.length} Shops Found
+                </span>
+              </div>
+              
+              {(selectedRating || selectedCategory) && (
+                <button
+                  onClick={handleResetFilters}
+                  className="text-[10px] font-bold text-amber-700 bg-amber-50 hover:bg-amber-100 px-2 py-0.5 rounded transition-colors duration-150 cursor-pointer"
+                >
+                  Clear Filters
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* ACTIVE FILTER STATUS BADGES */}
+          {(selectedRating || selectedCategory) && (
+            <div className="flex flex-wrap gap-2">
+              {selectedRating && (
+                <span className="text-xs font-semibold bg-emerald-50 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300 px-2.5 py-1 rounded-full border border-emerald-100 dark:border-emerald-900 flex items-center gap-1">
+                  ★ {selectedRating}+ Rating
+                  <button onClick={() => setSelectedRating(null)} className="cursor-pointer">
+                    <X className="w-3.5 h-3.5 hover:text-red-500" />
+                  </button>
+                </span>
+              )}
+              {selectedCategory && (
+                <span className="text-xs font-semibold bg-amber-50 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300 px-2.5 py-1 rounded-full border border-amber-100 dark:border-amber-900 flex items-center gap-1">
+                  🔥 {selectedCategory}
+                  <button onClick={() => setSelectedCategory(null)} className="cursor-pointer">
+                    <X className="w-3.5 h-3.5 hover:text-red-500" />
+                  </button>
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* FILTER PANEL DRAWER */}
+          {showFilters && (
+            <div className="p-4 bg-white/95 dark:bg-slate-900/95 backdrop-blur-md rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800/50 flex flex-col gap-4 transition-all duration-200">
+              <div className="flex items-center justify-between">
+                <h3 className="font-bold text-sm text-slate-800 dark:text-slate-200 flex items-center gap-1.5">
+                  <Sparkles className="w-4 h-4 text-amber-600" /> Filter Options
+                </h3>
+                <button
+                  onClick={() => setShowFilters(false)}
+                  className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 cursor-pointer"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+
+              {/* Rating filter */}
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">Minimum Rating</span>
+                <div className="flex gap-2">
+                  {[4.5, 4.7, 4.8].map((rating) => (
+                    <button
+                      key={rating}
+                      onClick={() => setSelectedRating(selectedRating === rating ? null : rating)}
+                      className={`flex-1 text-xs py-1.5 rounded-lg border transition-all duration-200 font-bold cursor-pointer ${
+                        selectedRating === rating
+                          ? "bg-[#003e1c] border-[#003e1c] text-white"
+                          : "border-slate-200 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800 text-slate-600 dark:text-slate-300"
+                      }`}
+                    >
+                      ★ {rating}+
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Specialty filter */}
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">Specialty Category</span>
+                <div className="flex flex-wrap gap-2">
+                  {["Beef", "Duck", "Seafood", "Crab", "Sweet"].map((category) => (
+                    <button
+                      key={category}
+                      onClick={() => setSelectedCategory(selectedCategory === category ? null : category)}
+                      className={`text-xs px-3 py-1.5 rounded-lg border transition-all duration-200 font-semibold cursor-pointer ${
+                        selectedCategory === category
+                          ? "bg-[#003e1c] border-[#003e1c] text-white"
+                          : "border-slate-200 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800 text-slate-600 dark:text-slate-300"
+                      }`}
+                    >
+                      {category}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT/CENTER COLUMN: FLOATING SEARCH BAR */}
+        <div className="relative w-full md:w-[450px] pointer-events-auto order-1 md:order-2">
+          <div className="bg-white/95 dark:bg-slate-900/95 backdrop-blur-md rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800/50 flex items-center p-1.5 pl-4 transition-all duration-200 focus-within:ring-2 focus-within:ring-[#003e1c]/25 focus-within:border-[#003e1c]">
+            <Search className="w-5 h-5 text-[#003e1c] dark:text-emerald-500 shrink-0" />
+            
+            <input
+              type="text"
+              placeholder="Search toddy shops or locations..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setShowSuggestions(true);
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              className="bg-transparent border-none outline-none flex-1 text-sm px-3 text-slate-800 dark:text-slate-100 placeholder-slate-400 w-full"
+            />
+
+            {searchQuery && (
+              <button
+                onClick={handleClearSearch}
+                className="p-1 mr-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 cursor-pointer"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className={`p-2.5 rounded-xl transition-all duration-200 shrink-0 flex items-center justify-center cursor-pointer ${
+                showFilters
+                  ? "bg-amber-600 text-white shadow-lg shadow-amber-600/20"
+                  : "bg-[#003e1c] hover:bg-[#002e14] text-white"
+              }`}
+              title="Filters"
+            >
+              <SlidersHorizontal className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* AUTOCOMPLETE SUGGESTIONS DROPDOWN */}
+          {showSuggestions && suggestions.length > 0 && (
+            <div className="absolute top-full left-0 right-0 mt-2 bg-white/95 dark:bg-slate-900/95 backdrop-blur-md rounded-2xl shadow-2xl border border-slate-100 dark:border-slate-800/50 overflow-hidden max-h-64 overflow-y-auto z-[2000] transition-all duration-150">
+              {suggestions.map((shop) => (
+                <button
+                  key={shop.id}
+                  onClick={() => handleSelectShop(shop)}
+                  className="w-full px-4 py-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/50 flex items-center justify-between border-b border-slate-50 last:border-0 dark:border-slate-800/30 transition-colors duration-150 cursor-pointer"
+                >
+                  <div className="flex items-start gap-2.5">
+                    <MapPin className="w-4 h-4 text-slate-400 mt-0.5 shrink-0" />
+                    <div>
+                      <p className="font-bold text-sm text-slate-800 dark:text-slate-200">{shop.name}</p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">📍 {shop.locationName}</p>
+                    </div>
+                  </div>
+                  <span className="text-[10px] font-bold text-emerald-800 bg-emerald-50 dark:bg-emerald-950 dark:text-emerald-300 px-2 py-0.5 rounded leaf-chip flex items-center gap-0.5 shrink-0">
+                    ★ {shop.rating}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+      </div>
     </div>
   );
 }

--- a/toddy_shop_frontend/src/features/explore/MapView.tsx
+++ b/toddy_shop_frontend/src/features/explore/MapView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import { useEffect, useRef } from "react";
+import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
@@ -16,20 +17,57 @@ L.Icon.Default.mergeOptions({
     "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
 });
 
-const toddyShops = [
-  {
-    id: 1,
-    name: "Heritage",
-    position: [9.4981, 76.3388],
-  },
-  {
-    id: 2,
-    name: "Kochi Toddy",
-    position: [9.9312, 76.2673],
-  },
-];
+interface Shop {
+  id: number;
+  name: string;
+  locationName: string;
+  position: [number, number];
+  description: string;
+  rating: number;
+  specialty: string;
+}
 
-export default function MapView() {
+interface MapViewProps {
+  shops: Shop[];
+  activeCenter: [number, number] | null;
+  activeShopId: number | null;
+  onMarkerClick: (shopId: number) => void;
+}
+
+// Custom hook helper to fly to active center smoothly
+function MapViewHandler({ activeCenter }: { activeCenter: [number, number] | null }) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (activeCenter) {
+      map.flyTo(activeCenter, 14, {
+        duration: 1.5,
+        easeLinearity: 0.25,
+      });
+    }
+  }, [activeCenter, map]);
+
+  return null;
+}
+
+export default function MapView({
+  shops,
+  activeCenter,
+  activeShopId,
+  onMarkerClick,
+}: MapViewProps) {
+  const markerRefs = useRef<{ [key: number]: L.Marker | null }>({});
+
+  useEffect(() => {
+    if (activeShopId && markerRefs.current[activeShopId]) {
+      // Short delay to allow map to fly or complete layout rendering
+      const timer = setTimeout(() => {
+        markerRefs.current[activeShopId]?.openPopup();
+      }, 350);
+      return () => clearTimeout(timer);
+    }
+  }, [activeShopId]);
+
   return (
     <MapContainer
       center={[9.9312, 76.2673]}
@@ -38,16 +76,46 @@ export default function MapView() {
       className="h-full w-full"
     >
       <TileLayer
-        attribution='&copy; OpenStreetMap contributors'
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
 
-      {toddyShops.map((shop) => (
+      <MapViewHandler activeCenter={activeCenter} />
+
+      {shops.map((shop) => (
         <Marker
           key={shop.id}
-          position={shop.position as [number, number]}
+          position={shop.position}
+          ref={(el) => {
+            markerRefs.current[shop.id] = el;
+          }}
+          eventHandlers={{
+            click: () => {
+              onMarkerClick(shop.id);
+            },
+          }}
         >
-          <Popup>{shop.name}</Popup>
+          <Popup className="custom-popup">
+            <div className="p-1 max-w-[220px]">
+              <h3 className="font-bold text-sm text-[#003e1c] font-heading leading-tight">
+                {shop.name}
+              </h3>
+              <p className="text-[10px] text-slate-500 font-medium mt-0.5">
+                📍 {shop.locationName}
+              </p>
+              <p className="text-xs text-slate-600 mt-2 leading-snug">
+                {shop.description}
+              </p>
+              <div className="mt-3 pt-2 border-t border-slate-100 flex items-center justify-between">
+                <span className="text-[10px] font-bold text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded">
+                  {shop.specialty}
+                </span>
+                <span className="text-xs font-bold text-emerald-700 flex items-center gap-0.5">
+                  ★ {shop.rating}
+                </span>
+              </div>
+            </div>
+          </Popup>
         </Marker>
       ))}
     </MapContainer>

--- a/toddy_shop_frontend/src/features/explore/MapView.tsx
+++ b/toddy_shop_frontend/src/features/explore/MapView.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// Fix default marker issue in Next.js
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
+
+const toddyShops = [
+  {
+    id: 1,
+    name: "Heritage",
+    position: [9.4981, 76.3388],
+  },
+  {
+    id: 2,
+    name: "Kochi Toddy",
+    position: [9.9312, 76.2673],
+  },
+];
+
+export default function MapView() {
+  return (
+    <MapContainer
+      center={[9.9312, 76.2673]}
+      zoom={10}
+      scrollWheelZoom={true}
+      className="h-full w-full"
+    >
+      <TileLayer
+        attribution='&copy; OpenStreetMap contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+
+      {toddyShops.map((shop) => (
+        <Marker
+          key={shop.id}
+          position={shop.position as [number, number]}
+        >
+          <Popup>{shop.name}</Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Description
This PR fully integrates Leaflet and OpenStreetMap on the `/explore` page. It addresses Server-Side Rendering (SSR) issues where static imports of Leaflet crash the Next.js server, while building a beautiful premium floating dashboard on top of the map.
- **Summary of changes:**
  - Created a new [ExploreClient client component](file:///d:/Kerala-toddy-finder/toddy_shop_frontend/src/features/explore/ExploreClient.tsx) that dynamically loads [MapView.tsx](file:///d:/Kerala-toddy-finder/toddy_shop_frontend/src/features/explore/MapView.tsx) with `ssr: false` to resolve server-side `window is not defined` errors.
  - Implemented an elegant green spinner loading fallback state for smooth transition hydration.
  - Refactored [page.tsx](file:///d:/Kerala-toddy-finder/toddy_shop_frontend/src/app/explore/page.tsx) to mount `<ExploreClient />` while safely keeping the page SEO `metadata` server-rendered.
  - Added a premium, modern glassmorphic floating UI overlay card at `/explore` with active "Interactive Map Live" pulse animations.
  - Configured `pointer-events` overlays so the underlying map is completely interactive and clickable, while maintaining full hover and interactivity on the floating panel.
- **Reasoning / motivation:**
  - Standard static imports of Leaflet crash on Next.js servers because they access browser-only variables (like `window`, `document`). Standardizing the dynamic wrapper with disabled SSR is the recommended, stable Next.js architecture.
- **Additional context:**
  - Fully compatible with both light and dark backgrounds.
---
## Type of Change
- [x] New feature
- [x] Refactor / code cleanup
---
## Related Issues
Closes #
---
## Tests
- [x] Tested happy path and edge cases manually
**Manual Test Steps:**
- Loaded `http://localhost:3000/explore`
- Verified map loads markers, maps tiles correctly, and handles the loader correctly.
- Verified that clicking and zooming on the map works under the overlay UI.
---
## Screenshots
<img width="898" height="609" alt="image" src="https://github.com/user-attachments/assets/882c3fcd-1706-4987-9367-4799018fe4b6" />

---
## Docs / Notes
- The Leaflet CSS is loaded globally via `@import` in `globals.css`.