### PR TITLE
fix(backend): add CORS support and JWT logout endpoint

### DIFF
--- a/toddy_shop_backend/.env.example
+++ b/toddy_shop_backend/.env.example
@@ -1,4 +1,8 @@
-DEBUG=True
+DEBUG=False
 SECRET_KEY=<your-secret-key, you can generate one at https://djecrety.ir/>
-ALLOWED_HOSTS=*
+ALLOWED_HOSTS=localhost,127.0.0.1
 DATABASE_URL=postgis://postgres:toddyfinder@db:5432/toddy_finder
+# Comma-separated list of origins allowed to make cross-origin requests.
+# In DEBUG mode with an empty list, all origins are allowed automatically.
+# Example for production: CORS_ALLOWED_ORIGINS=https://yourdomain.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/toddy_shop_backend/config/settings.py
+++ b/toddy_shop_backend/config/settings.py
@@ -37,6 +37,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "rest_framework_simplejwt.token_blacklist",
+    "corsheaders",
     "django_filters",
     "drf_spectacular",
     "import_export",
@@ -54,6 +55,7 @@ AUTH_USER_MODEL = "core.User"
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "corsheaders.middleware.CorsMiddleware",  # must be before CommonMiddleware
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -162,6 +164,29 @@ SIMPLE_JWT = {
     "BLACKLIST_AFTER_ROTATION": True,
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+# Comma-separated list of allowed origins, e.g.:
+#   CORS_ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+# In development with CORS_ALLOW_ALL_ORIGINS_IN_DEBUG=True, all origins are
+# permitted when DEBUG=True so local development works out of the box.
+
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[])
+CORS_ALLOW_ALL_ORIGINS = DEBUG and not CORS_ALLOWED_ORIGINS
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = [
+    "accept",
+    "accept-encoding",
+    "authorization",
+    "content-type",
+    "dnt",
+    "origin",
+    "user-agent",
+    "x-csrftoken",
+    "x-requested-with",
+]
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "Toddy Finder API",

--- a/toddy_shop_backend/core/tests.py
+++ b/toddy_shop_backend/core/tests.py
@@ -103,3 +103,84 @@ class UserDataAPITests(TestCase):
         response = self.client.get("/api/v1/profile/")
 
         self.assertEqual(response.status_code, 401)
+
+
+class AuthFlowTests(TestCase):
+    """Tests for the login → logout JWT blacklist flow and CORS header presence."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.customer_role = UserRole.objects.create(name="Customer")
+        self.user = User.objects.create_user(
+            username="authuser",
+            password="securepass123",
+            role=self.customer_role,
+        )
+
+    def test_login_returns_access_and_refresh_tokens(self):
+        response = self.client.post(
+            "/api/v1/auth/login/",
+            {"username": "authuser", "password": "securepass123"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access", response.data["data"])
+        self.assertIn("refresh", response.data["data"])
+
+    def test_logout_blacklists_refresh_token(self):
+        # Step 1: login and get tokens
+        login_resp = self.client.post(
+            "/api/v1/auth/login/",
+            {"username": "authuser", "password": "securepass123"},
+            format="json",
+        )
+        access = login_resp.data["data"]["access"]
+        refresh = login_resp.data["data"]["refresh"]
+
+        # Step 2: logout — should succeed
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+        logout_resp = self.client.post(
+            "/api/v1/auth/logout/",
+            {"refresh": refresh},
+            format="json",
+        )
+        self.assertEqual(logout_resp.status_code, 200)
+
+        # Step 3: try to use the blacklisted refresh token — should fail
+        self.client.credentials()
+        refresh_resp = self.client.post(
+            "/api/v1/auth/token/refresh/",
+            {"refresh": refresh},
+            format="json",
+        )
+        self.assertEqual(refresh_resp.status_code, 401)
+
+    def test_logout_without_refresh_token_returns_400(self):
+        login_resp = self.client.post(
+            "/api/v1/auth/login/",
+            {"username": "authuser", "password": "securepass123"},
+            format="json",
+        )
+        access = login_resp.data["data"]["access"]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+
+        response = self.client.post("/api/v1/auth/logout/", {}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_logout_requires_authentication(self):
+        response = self.client.post(
+            "/api/v1/auth/logout/",
+            {"refresh": "sometoken"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_cors_allow_all_origins_in_debug(self):
+        """In DEBUG mode (test runner sets DEBUG=True) an arbitrary Origin should
+        get an Access-Control-Allow-Origin response header."""
+        response = self.client.get(
+            "/api/v1/health/",
+            HTTP_ORIGIN="http://localhost:3000",
+        )
+        self.assertIn("Access-Control-Allow-Origin", response)
+

--- a/toddy_shop_backend/core/urls.py
+++ b/toddy_shop_backend/core/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
         views.TokenRefreshAPIView.as_view(),
         name="auth-token-refresh",
     ),
+    path("auth/logout/", views.LogoutView.as_view(), name="auth-logout"),
     path("auth/me/", views.MeView.as_view(), name="auth-me"),
     path("profile/", views.UserProfileView.as_view(), name="user-profile"),
     path("favorites/", views.UserFavoriteView.as_view(), name="user-favorites"),

--- a/toddy_shop_backend/core/views.py
+++ b/toddy_shop_backend/core/views.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import generics, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from shared.permissions import IsAdminOrReadOnly
@@ -91,7 +92,43 @@ class TokenRefreshAPIView(TokenRefreshView):
 
 
 @extend_schema(tags=["Authentication"])
+class LogoutView(generics.GenericAPIView):
+    """
+    Blacklists the supplied refresh token, effectively logging the user out.
+
+    The access token continues to work until it naturally expires (1 hour),
+    but no new access tokens can be minted from a blacklisted refresh token.
+
+    Request body: { "refresh": "<refresh_token>" }
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        refresh_token = request.data.get("refresh")
+        if not refresh_token:
+            return APIResponse(
+                data=None,
+                message="Refresh token is required.",
+                status=400,
+                is_success=False,
+            )
+        try:
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+        except TokenError:
+            return APIResponse(
+                data=None,
+                message="Invalid or already expired token.",
+                status=400,
+                is_success=False,
+            )
+        return APIResponse(data=None, message="Successfully logged out.")
+
+
+@extend_schema(tags=["Authentication"])
 class MeView(generics.RetrieveUpdateAPIView):
+
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 

--- a/toddy_shop_backend/pyproject.toml
+++ b/toddy_shop_backend/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "whitenoise>=6.9.0",
     "gunicorn>=23.0.0",
     "psycopg[binary]>=3.1.18",
-    "django-import-export>=4.4.0"
+    "django-import-export>=4.4.0",
+    "django-cors-headers>=4.7.0",
 ]
 
 [tool.ruff]

--- a/toddy_shop_backend/requirements.txt
+++ b/toddy_shop_backend/requirements.txt
@@ -11,4 +11,5 @@ PyJWT==2.13.0
 sqlparse==0.5.5
 tzdata==2026.2; sys_platform == "win32"
 whitenoise==6.12.0
+django-cors-headers==4.9.0
 django-import-export==4.4.1

--- a/toddy_shop_backend/uv.lock
+++ b/toddy_shop_backend/uv.lock
@@ -44,6 +44,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
 name = "django-environ"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +188,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-cors-headers" },
     { name = "django-environ" },
     { name = "django-filter" },
     { name = "django-import-export" },
@@ -190,6 +204,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=6.0.4" },
+    { name = "django-cors-headers", specifier = ">=4.7.0" },
     { name = "django-environ", specifier = ">=0.13.0" },
     { name = "django-filter", specifier = ">=24.0" },
     { name = "django-import-export", specifier = ">=4.4.0" },


### PR DESCRIPTION
## What I changed and why

While setting up the project locally I noticed two things that were 
blocking any actual frontend-backend integration:

1. **CORS was completely missing** — the Next.js frontend on port 3000 
   can't talk to the Django API on port 8000 without CORS headers. The 
   browser just blocks the requests. Without this, the whole stack is 
   basically unusable end-to-end.

2. **No logout endpoint** — once a user logs in, there was no way to 
   invalidate their JWT. Tokens just hang around until they expire on 
   their own. Added a proper logout that blacklists the refresh token 
   using the `token_blacklist` app that was already installed but unused.

## Changes

**Backend (`toddy_shop_backend`)**
- Added `django-cors-headers==4.9.0` to dependencies
- Wired `CorsMiddleware` before `CommonMiddleware` in settings (this 
  order matters — it's a requirement from the library docs)
- `CORS_ALLOWED_ORIGINS` is pulled from the `.env` file, so local dev 
  stays flexible while production stays locked down
- Added `POST /api/v1/auth/logout/` — accepts a refresh token, 
  blacklists it, returns 200. If the token is already blacklisted or 
  missing, returns the appropriate error.
- Fixed `.env.example` — `DEBUG` was set to `True` which is a bad 
  default for anyone copy-pasting the example into production

## How I tested this

Followed the setup in CONTRIBUTING.md:

```bash
docker-compose up -d --build
docker-compose exec backend uv run python manage.py migrate
docker-compose exec backend uv run python manage.py test
