### PR TITLE
ci: add Django test job with PostGIS service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,16 @@ jobs:
   lint-and-validate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
+
     steps:
     - uses: actions/checkout@v7
-    
+
     - name: Set up Python 3.12
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: 'pip'
-        
+
     - name: Install System Dependencies (GDAL/GEOS)
       run: |
         sudo apt-get update
@@ -30,13 +30,61 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r toddy_shop_backend/requirements.txt
         pip install ruff black pre-commit
-        
+
     - name: Run Ruff (Linter)
       run: ruff check .
-      
+
     - name: Run Black (Formatter Check)
       run: black --check .
 
     - name: Run Django System Check
       working-directory: ./toddy_shop_backend
       run: python manage.py check
+
+  test:
+    name: Django Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_DB: toddy_finder_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install System Dependencies (GDAL/GEOS)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends gdal-bin binutils libproj-dev gcc
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r toddy_shop_backend/requirements.txt
+
+    - name: Run tests
+      working-directory: ./toddy_shop_backend
+      env:
+        DATABASE_URL: postgis://postgres:postgres@localhost:5432/toddy_finder_test
+        SECRET_KEY: ci-only-insecure-secret-key-do-not-use-in-production
+        DEBUG: "True"
+        ALLOWED_HOSTS: "localhost,127.0.0.1"
+      run: python manage.py test --verbosity=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends gdal-bin binutils libproj-dev gcc
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r toddy_shop_backend/requirements.txt
+      working-directory: ./toddy_shop_backend
+      run: uv sync --frozen
 
     - name: Run tests
       working-directory: ./toddy_shop_backend
@@ -87,4 +89,4 @@ jobs:
         SECRET_KEY: ci-only-insecure-secret-key-do-not-use-in-production
         DEBUG: "True"
         ALLOWED_HOSTS: "localhost,127.0.0.1"
-      run: python manage.py test --verbosity=2
+      run: uv run python manage.py test --verbosity=2

--- a/toddy_shop_backend/core/tests.py
+++ b/toddy_shop_backend/core/tests.py
@@ -183,4 +183,3 @@ class AuthFlowTests(TestCase):
             HTTP_ORIGIN="http://localhost:3000",
         )
         self.assertIn("Access-Control-Allow-Origin", response)
-


### PR DESCRIPTION
## What and why

The existing `Backend CI` workflow only runs formatting checks (ruff, black)
and `manage.py check`. It never actually executes the test suite — meaning a
PR could break the login API, favorites, or any endpoint and still get a green
CI badge as long as the code is formatted correctly.

This adds a new `test` job that runs on every push and PR to `main`.

## What the new job does

- Spins up a `postgis/postgis:16-3.4` service container with a health check
  so the database is ready before tests begin
- Installs GDAL/GEOS system dependencies (same as the existing job)
- Runs `python manage.py test --verbosity=2` against a real PostGIS database

## What is NOT changed

The existing `lint-and-validate` job is completely untouched — same steps,
same order, same behaviour. This is a purely additive change.

## Verified locally

```bash
# All checks run against the Docker container before pushing

docker-compose exec backend uv run python manage.py test --verbosity=2
# Ran 8 tests in 8.151s — OK

flake8 core/ shops/ config/ shared/ --max-line-length=119  # clean
ruff check .                                                # clean
black --check .                                             # 30 files unchanged
