### PR TITLE
fix(nav): correct districts link to use absolute path

### DIFF
--- a/toddy_shop_frontend/src/features/home/components/Navbar.tsx
+++ b/toddy_shop_frontend/src/features/home/components/Navbar.tsx
@@ -8,7 +8,7 @@ export default function Navbar() {
     const navLinks = [
         { name: "Home", href: "/" },
         { name: "Explore Map", href: "/explore" },
-        { name: "Districts", href: "#districts" },
+        { name: "Districts", href: "/#districts" },
         { name: "Community", href: "/community" },
         { name: "About", href: "/about" },
     ];


### PR DESCRIPTION
## What and why
Previously, the "Districts" link in the Navbar was using a relative anchor tag (`href="#districts"`). This caused a routing bug where clicking "Districts" from any page other than the Home page (e.g. `/community`) would attempt to navigate to `/community#districts`, doing nothing.

This PR fixes the issue by updating the link to use an absolute path (`href="/#districts"`), ensuring that clicking it from any page correctly routes the user back to the Home page and scrolls to the Districts section.

## What the new changes do
- Updated `Navbar.tsx` to use `/` in the districts href.

## Verified locally
- Verified clicking "Districts" from `/community` routes back to `/` and scrolls down to the map correctly.
